### PR TITLE
fix: issue 17

### DIFF
--- a/src/_pages/auth-callback/ui/KakaoCallbackPage.tsx
+++ b/src/_pages/auth-callback/ui/KakaoCallbackPage.tsx
@@ -10,7 +10,6 @@ const KAKAO_CODE_QUERY_KEY = 'code'
 const DEFAULT_REDIRECT_PATH = '/main'
 const REFRESH_TOKEN_CLEAR_ENDPOINT = '/api/auth/token/refresh/clear'
 
-// const createDeviceUuid = () => (typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : '')
 export const createUuidForRegex = (): string => {
   // 가장 간단하고 표준(UUID v4)
   if (typeof crypto?.randomUUID === 'function') {

--- a/src/app/(public)/auth/kakao/callback/complete/page.tsx
+++ b/src/app/(public)/auth/kakao/callback/complete/page.tsx
@@ -1,5 +1,11 @@
+import { Suspense } from 'react'
+
 import { KakaoCallbackPage } from '@/_pages/auth-callback'
 
 export default function Page() {
-  return <KakaoCallbackPage />
+  return (
+    <Suspense fallback={null}>
+      <KakaoCallbackPage />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
#17 

## 개요
* CI에서 `next build` 실행 시 `/auth/kakao/callback/complete` 페이지 프리렌더 단계에서 빌드가 실패
* 원인은 해당 페이지에서 `useSearchParams()`를 사용하면서 CSR bailout이 발생했는데, Suspense boundary가 없어 빌드 단계에서 에러가 발생
* 이를 해결하기 위해 `page.tsx`에서 Client 컴포넌트를 `<Suspense>`로 감싸도록 수정

## 변경사항
* `/auth/kakao/callback/complete` 라우트의 `page.tsx`에 `<Suspense>`를 추가
* `useSearchParams()`를 사용하는 컴포넌트는 Client Component로 유지하고, `page.tsx`에서 Suspense boundary를 제공하도록 분리/감싸기 처리

## Screenshots (UI 변경 시)
* N/A

## How to test
* [ ] 로컬에서 `pnpm next build` 실행 시 빌드가 실패하지 않는지 확인
* [ ] `/api/auth/kakao` → 카카오 로그인 진행 후 `/auth/kakao/callback/complete?code=...`로 진입되는 플로우 확인
* [ ] 콜백 페이지에서 `/api/auth/kakao/exchange` 호출이 정상 수행되고 `/main`으로 리다이렉트되는지 확인
* [ ] code 누락/에러 케이스에서 `/login`으로 이동하는지 확인

## 관련 이슈
* Issue: #

## Checklist
* [ ] lint/typecheck 통과
* [ ] 주요 케이스 테스트 완료
* [ ] 문서/주석 업데이트(필요 시)

## References
* Docs:
  * Next.js App Router `useSearchParams()` (CSR bailout) 관련 가이드
  * React Suspense boundary 패턴 (Client Component 래핑)
