### PR TITLE
fix: fix layout on safary and ux after upload audio

### DIFF
--- a/src/_pages/levelup/ui/LevelUpFeedbackPage.tsx
+++ b/src/_pages/levelup/ui/LevelUpFeedbackPage.tsx
@@ -116,7 +116,7 @@ export function LevelUpFeedbackPage() {
       </div>
       <div className="mt-auto flex w-full flex-col items-center justify-center gap-4">
         <p className="mb-3 text-sm">남은 학습 횟수: {remainingAttempts}</p>
-        <div className="flex w-full items-center justify-center gap-4 pb-6">
+        <div className="mb-6 flex w-full items-center justify-center gap-4">
           <Button
             variant="levelup_feedback_btn"
             onClick={() => {

--- a/src/_pages/mypage/cards/details/ui/CardDetailsPage.tsx
+++ b/src/_pages/mypage/cards/details/ui/CardDetailsPage.tsx
@@ -44,7 +44,7 @@ export function CardDetailsPage() {
       <div className="flex w-full justify-center">
         <p className="text-sm">남은 학습 횟수: {remainingAttempts}</p>
       </div>
-      <div className="mt-auto flex w-full justify-center pb-6">
+      <div className="mt-auto mb-6 flex w-full justify-center">
         <Button
           className="border-primary text-primary bg-var(--color-background) h-10 w-60 rounded-xl border"
           size={'lg'}


### PR DESCRIPTION
## 개요

* Safari 환경에서 일부 UI 레이아웃이 깨지고(버튼이 하단에 가려짐), 오디오 업로드 이후 UX 흐름이 어색한 문제 발생하여 수정

## 변경사항
* Safari에서 보이지 않던 버튼들이 가려지지 않도록 하단 여백(`pb-6`)을 추가
* 오디오 업로드 이후 UX(화면 구성/동작 흐름)를 개선

## Screenshots (UI 변경 시)


## How to test
* [ ] Safari(모바일/데스크탑)에서 해당 화면 진입 후 하단 버튼이 정상적으로 노출되는지 확인
* [ ] 오디오 녹음/업로드 수행 후 업로드 완료 이후 UX 흐름이 의도대로 동작하는지 확인

## 관련 이슈
* Issue: #

## Checklist
* [ ] lint/typecheck 통과
* [ ] 주요 케이스 테스트 완료
* [ ] 문서/주석 업데이트(필요 시)

## References

* Docs:
