### PR TITLE
fix: profile edit modal profile image load error

### DIFF
--- a/src/entities/user/ui/Avatar.tsx
+++ b/src/entities/user/ui/Avatar.tsx
@@ -1,14 +1,21 @@
 'use client'
 
-import Image from 'next/image'
-import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import Image, { type StaticImageData } from 'next/image'
+import { useEffect, useRef, useState } from 'react'
 
 import { DefaultAvatar } from '@/shared'
 
+import { useProfile, useSetProfile } from '../model/useUserStore'
+
+import type { UserProfile } from '../model/userProfile'
+
+type AvatarImageSource = string | StaticImageData
+
 interface AvatarProps {
-  avatar_src: string
+  avatar_src: string | StaticImageData
   size: number
-  onError?: () => void
+  alt?: string
 }
 
 const KAKAO_CDN_HTTP_PREFIX = 'http://k.kakaocdn.net'
@@ -16,8 +23,30 @@ const KAKAO_CDN_HTTPS_PREFIX = 'https://k.kakaocdn.net'
 const S3_HTTP_PREFIX = 'http://imymemine1.s3.ap-northeast-2.amazonaws.com'
 const S3_HTTPS_PREFIX = 'https://imymemine1.s3.ap-northeast-2.amazonaws.com'
 const PLACEHOLDER_CLASSNAME = 'absolute inset-0 rounded-full bg-secondary/60'
+const MY_PROFILE_QUERY_KEY = ['myProfile'] as const
 
-const normalizeAvatarSrc = (src: string) => {
+const isS3PresignedUrl = (src: string) => {
+  if (!src) return false
+  try {
+    const url = new URL(src)
+    const isS3Host =
+      /\.s3[.-][a-z0-9-]+\.amazonaws\.com$/.test(url.hostname) ||
+      /\.s3\.amazonaws\.com$/.test(url.hostname)
+    const hasPresignedParams =
+      url.searchParams.has('X-Amz-Signature') ||
+      url.searchParams.has('X-Amz-Algorithm') ||
+      url.searchParams.has('X-Amz-Credential') ||
+      url.searchParams.has('X-Amz-Date')
+
+    return isS3Host && hasPresignedParams
+  } catch {
+    return false
+  }
+}
+
+const normalizeAvatarSrc = (src: AvatarImageSource) => {
+  if (typeof src !== 'string') return src
+
   if (src.startsWith(KAKAO_CDN_HTTP_PREFIX)) {
     return `${KAKAO_CDN_HTTPS_PREFIX}${src.slice(KAKAO_CDN_HTTP_PREFIX.length)}`
   }
@@ -27,11 +56,42 @@ const normalizeAvatarSrc = (src: string) => {
   return src
 }
 
-export function Avatar({ avatar_src, size, onError }: AvatarProps) {
+export function Avatar({ avatar_src, size, alt = 'profile image' }: AvatarProps) {
+  const queryClient = useQueryClient()
+  const profile = useProfile()
+  const setProfile = useSetProfile()
   const isFallback = !avatar_src
   const src = isFallback ? DefaultAvatar : normalizeAvatarSrc(avatar_src)
-  const [loadedSrc, setLoadedSrc] = useState<string | null>(isFallback ? src : null)
+  const [loadedSrc, setLoadedSrc] = useState<AvatarImageSource | null>(isFallback ? src : null)
+
+  // 현재 avatar URL에 대한 재발급 요청 1회 제한 장치
+  const retriedRef = useRef(false)
   const isImageLoaded = isFallback || loadedSrc === src
+
+  // 새 아바타 URL(특히 presigned URL)이 들어오면 재시도 플래그를 다시 열어 재시도 가능
+  useEffect(() => {
+    retriedRef.current = false
+  }, [avatar_src])
+
+  const handleAvatarError = async () => {
+    // 기본 이미지/카카오 CDN/일반 URL은 presigned 만료 재발급 대상이 아니므로 무시
+    if (typeof avatar_src !== 'string' || !avatar_src || !isS3PresignedUrl(avatar_src)) return
+    // 같은 URL에서 에러가 반복될 때 invalidate 무한 반복을 막는다.(중복 재발급 요청 방지)
+    if (retriedRef.current) return
+
+    retriedRef.current = true
+    await queryClient.invalidateQueries({ queryKey: MY_PROFILE_QUERY_KEY })
+
+    // invalidate 후 active query가 갱신됐다면, 캐시의 최신 프로필을 store에도 반영
+    // 이렇게 해야 store 기반으로 이미지를 렌더하는 화면(ProfileImageInput 등)도 재발급된 presigned URL을 바로 사용할 수 있다.
+    const nextProfile = queryClient.getQueryData<UserProfile>(MY_PROFILE_QUERY_KEY)
+    if (!nextProfile) return
+    if (profile.id === nextProfile.id && profile.profileImageUrl === nextProfile.profileImageUrl) {
+      return
+    }
+
+    setProfile(nextProfile)
+  }
 
   return (
     <div
@@ -41,14 +101,16 @@ export function Avatar({ avatar_src, size, onError }: AvatarProps) {
       {isImageLoaded ? null : <div className={PLACEHOLDER_CLASSNAME} />}
       <Image
         src={src}
-        alt="profile image"
+        alt={alt}
         width={size}
         height={size}
         className={[
           'h-full w-full object-cover object-center transition-opacity duration-200',
           isImageLoaded ? 'opacity-100' : 'opacity-0',
         ].join(' ')}
-        onError={onError}
+        onError={() => {
+          void handleAvatarError()
+        }}
         priority={isFallback}
         onLoad={() => {
           setLoadedSrc(src)

--- a/src/features/profile-edit/ui/ProfileEditModal.tsx
+++ b/src/features/profile-edit/ui/ProfileEditModal.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { useProfile, useProfileImage, useSetProfile, getMyProfile } from '@/entities/user'
+import {
+  useProfile,
+  useProfileImage,
+  useSetProfile,
+  getMyProfile,
+  useMyProfileQuery,
+} from '@/entities/user'
 import { useAccessToken } from '@/features/auth'
 import {
   ProfileImageInput,
@@ -51,6 +57,10 @@ export function ProfileEditModal({ open, onOpenChange }: ProfileEditModalProps) 
   const accessToken = useAccessToken()
   const profile = useProfile()
   const setProfile = useSetProfile()
+  // 서버 기준 최신 프로필(만료된 presigned URL 재발급 반영 가능)
+  const { data: myProfile } = useMyProfileQuery(accessToken, {
+    enabled: open && Boolean(accessToken),
+  })
 
   const handleProfileEdit = async () => {
     if (!accessToken) return
@@ -99,9 +109,10 @@ export function ProfileEditModal({ open, onOpenChange }: ProfileEditModalProps) 
     onOpenChange(false)
   }
 
+  // 로컬 store에 남아있는 마지막 프로필 이미지 URL (query 지연/실패 시 fallback)
   const storeProfileImageUrl = useProfileImage()
 
-  // ✅ 우선순위: (미리보기 props) > (store) > (기본)
+  // ✅ 우선순위: (미리보기 props) > (myProfile query) > (store) > (기본)
 
   return (
     <Dialog
@@ -117,9 +128,11 @@ export function ProfileEditModal({ open, onOpenChange }: ProfileEditModalProps) 
           imageSrc={
             imagePreview
               ? imagePreview
-              : storeProfileImageUrl
-                ? storeProfileImageUrl
-                : defaultAvatar
+              : myProfile?.profileImageUrl
+                ? myProfile.profileImageUrl
+                : storeProfileImageUrl
+                  ? storeProfileImageUrl
+                  : defaultAvatar
           }
           onChange={handleFileChange}
           acceptTypes={acceptTypes}

--- a/src/features/profile-edit/ui/ProfileImageInput.tsx
+++ b/src/features/profile-edit/ui/ProfileImageInput.tsx
@@ -1,6 +1,7 @@
-import Image, { type StaticImageData } from 'next/image'
+import { type StaticImageData } from 'next/image'
 import { type ChangeEventHandler } from 'react'
 
+import { Avatar } from '@/entities/user'
 import { HelperText } from '@/shared'
 import { Input } from '@/shared/ui/input'
 
@@ -27,13 +28,10 @@ export function ProfileImageInput({
         className={`bg-muted flex items-center justify-center rounded-full ${IMAGE_SIZE_CLASS}`}
         htmlFor={inputId}
       >
-        <Image
-          unoptimized
-          src={imageSrc}
+        <Avatar
+          avatar_src={imageSrc}
           alt="프로필 이미지"
-          className={`rounded-full object-cover ${IMAGE_SIZE_CLASS}`}
-          width={150}
-          height={150}
+          size={150}
         />
         <Input
           className="sr-only"

--- a/src/widgets/profile/ui/ProfileDashboard.tsx
+++ b/src/widgets/profile/ui/ProfileDashboard.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useQueryClient } from '@tanstack/react-query'
 import { ChevronLeft } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useRef } from 'react'
 
 import {
   Avatar,
@@ -19,28 +17,6 @@ const AVATAR_SIZE_PX = 60
 const FALLBACK_NICKNAME = '로딩중...'
 const FALLBACK_STAT_VALUE = 0
 
-// presigned GET URL이면 보통 X-Amz-* 쿼리가 붙음
-const isS3PresignedUrl = (src: string) => {
-  if (!src) return false
-  try {
-    const u = new URL(src)
-    const host = u.hostname // dev-imymemine.s3.ap-northeast-2.amazonaws.com
-
-    // ✅ S3 host 패턴(virtual-hosted-style) + presigned 파라미터 존재 여부
-    const isS3Host =
-      /\.s3[.-][a-z0-9-]+\.amazonaws\.com$/.test(host) || /\.s3\.amazonaws\.com$/.test(host)
-    const hasAmz =
-      u.searchParams.has('X-Amz-Signature') ||
-      u.searchParams.has('X-Amz-Algorithm') ||
-      u.searchParams.has('X-Amz-Credential') ||
-      u.searchParams.has('X-Amz-Date')
-
-    return isS3Host && hasAmz
-  } catch {
-    return false
-  }
-}
-
 interface ProfileDashboardProps {
   navigateToMyPage?: boolean
   showBackButton?: boolean
@@ -52,40 +28,14 @@ export function ProfileDashboard({
   showBackButton = false,
   deferAvatarImageUntilProfileReady = false,
 }: ProfileDashboardProps) {
-  // 라우팅/캐시/토큰
+  // 라우팅/토큰
   const router = useRouter()
-  const queryClient = useQueryClient()
   const accessToken = useAccessToken()
   const profile = useProfile()
   const { data: myProfile } = useMyProfileQuery(accessToken, { enabled: Boolean(accessToken) })
   useSyncMyProfile({ accessToken, myProfile })
 
   // ✅ 렌더는 store 기준으로 고정 (query 응답으로 인한 2회 변경 방지)
-
-  // ✅ 무한 루프 방지: 같은 렌더 사이클에서 계속 에러 나면 invalidate 반복될 수 있음
-  const retriedRef = useRef(false)
-
-  useEffect(() => {
-    retriedRef.current = false
-  }, [profile.profileImageUrl])
-
-  const handleAvatarError = async () => {
-    // presigned URL 만료 시 재발급 유도
-    const url = profile.profileImageUrl
-
-    // ✅ 카카오 CDN/기본 이미지면 만료 이슈가 아니라서 재발급 시도 X
-    if (!url || !isS3PresignedUrl(url)) return
-
-    if (!accessToken) return
-    if (retriedRef.current) return
-    retriedRef.current = true
-
-    // ✅ 캐시 무효화 → /users/me 재호출 → profileImageUrl 새로 받기
-    await queryClient.invalidateQueries({ queryKey: ['myProfile'] })
-
-    // ✅ 새 URL을 받으면 다시 재시도 가능하게 풀어주고 싶으면,
-    // profile.profileImageUrl이 바뀌는 시점(useEffect)에서 retriedRef를 false로 리셋하면 됨
-  }
 
   const handleNavigateToMyPage = () => {
     // 내 페이지 이동
@@ -127,7 +77,6 @@ export function ProfileDashboard({
             <Avatar
               avatar_src={avatarSrcForRender}
               size={AVATAR_SIZE_PX}
-              onError={handleAvatarError} // ✅ 상위에서 처리
             />
           </div>
           <Nickname nickname={isProfileReady ? profile.nickname : FALLBACK_NICKNAME} />


### PR DESCRIPTION
## 개요
* `ProfileEditModal`에서 **만료된 S3 presigned profile image URL로 인해 이미지가 깨진 채 남는 문제**를 수정 #102 
* 이미지 로딩 실패 시 복구 로직을 `Avatar`로 모아 **에러 복구 + React Query 캐시 갱신 + zustand 프로필 동기화**까지 한 흐름으로 처리
* `ProfileEditModal`이 `myProfile` query를 직접 구독하도록 보강해 **invalidate → refetch → UI 반영**이 안정적으로 이어지도록 개선
---

## 변경사항
### 1) `Avatar`로 아바타 이미지 에러 복구 책임 이동
* 파일: `src/entities/user/ui/Avatar.tsx`
* 변경 내용:
  * presigned S3 URL 만료 감지 로직 추가 (`isS3PresignedUrl`)
  * 이미지 로딩 실패 시 `myProfile` query invalidate (`['myProfile']`)
  * 동일 URL에서 무한 재시도 방지 (`retriedRef`)
  * **invalidate 이후 최신 `myProfile`을 읽어 zustand `useProfile`까지 `setProfile()`로 동기화**
  * `avatar_src` 타입 확장: `string | StaticImageData`
  * `alt` prop 지원 추가

### 2) `ProfileDashboard`의 중복 에러 처리 로직 제거
* 파일: `src/widgets/profile/ui/ProfileDashboard.tsx`
* 변경 내용:
  * 기존 `handleAvatarError` 삭제
  * `isS3PresignedUrl` helper 삭제
  * `useQueryClient`, `useEffect`, `useRef` 제거
  * `Avatar`에 `onError` 전달하던 구조 제거
* 효과:
  * 대시보드는 UI 조합에 집중, 복구는 `Avatar` 단일 책임으로 수렴

### 3) `ProfileImageInput`에서 `Avatar` 재사용
* 파일: `src/features/profile-edit/ui/ProfileImageInput.tsx`
* 변경 내용:
  * 기존 `next/image` 렌더 제거 → `Avatar`로 통일 (`avatar_src={imageSrc}`, `size={150}`)
* 효과:
  * 대시보드/프로필 수정 모달의 아바타 렌더링 로직 일관화

### 4) `ProfileEditModal`에서 `myProfile` query 직접 구독 + 이미지 소스 우선순위 조정
* 파일: `src/features/profile-edit/ui/ProfileEditModal.tsx`
* 변경 내용:
  * `useMyProfileQuery(accessToken, { enabled: open && Boolean(accessToken) })` 추가
  * `ProfileImageInput.imageSrc` 우선순위 변경:
    1. `imagePreview` (로컬 미리보기)
    2. `myProfile?.profileImageUrl` (서버 최신값)
    3. `storeProfileImageUrl` (zustand fallback)
    4. `defaultAvatar`
  * 관련 역할 설명 주석 추가
* 효과:
  * 모달이 열려 있을 때 `myProfile` query가 active → `Avatar` invalidate 복구가 **즉시 refetch로 이어질 가능성 증가**
  * presigned URL 만료 복구 안정성 개선

---

## Screenshots (UI 변경 시)

---

## How to test

1. 설치/실행

   * `pnpm i`
   * `pnpm dev`

2. 기본 동작 확인

   * 로그인 후 프로필 수정 모달(`ProfileEditModal`) 오픈
   * 프로필 이미지가 정상 렌더되는지 확인
   * 이미지 업로드/미리보기(`imagePreview`)가 있을 때 우선 적용되는지 확인

3. presigned URL 만료/에러 복구 확인 (재현 가능 시)

   * 만료된 S3 presigned URL(403/AccessDenied) 상황에서:

     * `Avatar`에서 1회만 invalidate 수행되는지(`retriedRef`) 확인
     * `['myProfile']` invalidate → refetch가 발생하는지 확인
     * refetch된 `myProfile.profileImageUrl`로 이미지가 정상 복구되는지 확인
     * zustand `useProfile`에도 최신 프로필이 동기화되는지 확인(대시보드/모달 양쪽)

4. 회귀 확인

   * ProfileDashboard에서도 동일하게 Avatar가 깨지지 않고 정상적으로 복구되는지 확인
   * `ProfileImageInput`이 `Avatar` 기반으로 정상 렌더되는지 확인

---

## 참고 커밋

* `08f00b8` fix: profile edit modal profile image load error
