### PR TITLE
feat: refine pvp create flow and matching open state ui

### DIFF
--- a/src/_pages/pvp/create/ui/PvPRoomCreatePage.tsx
+++ b/src/_pages/pvp/create/ui/PvPRoomCreatePage.tsx
@@ -1,28 +1,43 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
+import { useCallback, useRef, useState } from 'react'
+
 import { usePvPRoomCreateExitGuard } from '@/features/pvp'
 import { ModeHeader } from '@/shared'
 import { PvPMatchingCreate } from '@/widgets/pvp-matching-create'
 
 export function PvPRoomCreatePage() {
-  const {
-    isExitAlertOpen,
-    handleBack,
-    handleExitCancel,
-    handleExitConfirm,
-    handleWaitingChange,
-    setIsExitAlertOpen,
-  } = usePvPRoomCreateExitGuard()
+  const [isCreatingRoom, setIsCreatingRoom] = useState(false)
+  const createPageBackHandlerRef = useRef<(() => void) | null>(null)
+  const router = useRouter()
+  const { isExitAlertOpen, handleExitCancel, handleExitConfirm, setIsExitAlertOpen } =
+    usePvPRoomCreateExitGuard()
+
+  const handleHeaderBack = useCallback(() => {
+    if (createPageBackHandlerRef.current) {
+      createPageBackHandlerRef.current()
+      return
+    }
+
+    router.replace('/pvp')
+  }, [router])
+
+  const handleCreatePageBackHandlerChange = useCallback((onBackHandler: () => void) => {
+    createPageBackHandlerRef.current = onBackHandler
+  }, [])
 
   return (
     <div className="flex w-full flex-1 flex-col">
       <ModeHeader
         mode="pvp"
         step="matching_create"
-        onBack={handleBack}
+        onBack={handleHeaderBack}
+        backDisabled={isCreatingRoom}
       />
       <PvPMatchingCreate
-        onExitGuardChange={handleWaitingChange}
+        onCreatingRoomChange={setIsCreatingRoom}
+        onBackHandlerChange={handleCreatePageBackHandlerChange}
         isExitAlertOpen={isExitAlertOpen}
         onExitAlertOpenChange={setIsExitAlertOpen}
         onExitConfirm={handleExitConfirm}

--- a/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
+++ b/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
@@ -5,32 +5,35 @@ import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { PvPCategory, PvPKeyword } from '@/entities/pvp-card'
+import { usePvPRoomDetails } from '@/entities/room'
 import { useMyProfileQuery, useUserId } from '@/entities/user'
 import { useAccessToken } from '@/features/auth'
 import { FeedbackLoader } from '@/features/levelup-feedback'
 import {
   usePvPMatchingExitGuard,
+  PvPMatchingWaiting,
   PvPParticipants,
   PvPThinkingCountdown,
-  // 준비 버튼 클릭 시 RECORDING 시작 요청 API
   startPvPRecording,
-  // 매칭 페이지 실시간 소켓 메시지 처리 훅
   usePvPMatchingSocket,
-  // PvP 녹음 제어 훅
   usePvPRecordController,
-  // RoomList에서 join해둔 결과를 캐시로 읽는 쿼리 훅
   usePvPRoomJoinQuery,
 } from '@/features/pvp'
 import { MicrophoneBox } from '@/features/record'
 import { AlertModal, Button, ModeHeader, RecordTipBox, StatusMessage } from '@/shared'
 
 const ERROR_MESSAGE = '매칭 방에 입장하지 못했습니다.'
+const ROOM_ACCESS_DENIED_MESSAGE = '참여 중인 매칭 방이 아닙니다.'
 const INVALID_ROOM_ID_MESSAGE = '잘못된 방 정보입니다.'
+const LOADING_MESSAGE = '매칭 방 정보를 불러오는 중입니다.'
 const EMPTY_GUEST_NAME = '...'
+
+const OPEN_ROOM_STATUS = 'OPEN'
 const THINKING_ROOM_STATUS = 'THINKING'
 const RECORDING_ROOM_STATUS = 'RECORDING'
 const PROCESSING_ROOM_STATUS = 'PROCESSING'
 const FINISHED_ROOM_STATUS = 'FINISHED'
+
 const START_RECORDING_ERROR_MESSAGE = '녹음 시작 요청에 실패했습니다. 다시 시도해주세요.'
 const OPPONENT_SUBMITTED_TOAST_MESSAGE = '상대방이 음성 제출을 완료했습니다.'
 const PVP_FEEDBACK_PATH_PREFIX = '/pvp/feedback'
@@ -47,23 +50,45 @@ export function PvPMatchingPage() {
   const shouldFetchMyProfile = Boolean(accessToken) && storeUserId <= 0
   const myProfileQuery = useMyProfileQuery(accessToken, { enabled: shouldFetchMyProfile })
   const myUserId = storeUserId > 0 ? storeUserId : myProfileQuery.data?.id
+  const hasMyUserId = typeof myUserId === 'number' && myUserId > 0
 
-  // 준비 요청(start-recording) 중복 호출 방지 state
-  const [isStartingRecordingRequest, setIsStartingRecordingRequest] = useState(false)
-  // 내가 준비 버튼을 눌렀는지 state (중복 클릭/중복 요청 방지)
-  const [isReadySubmitted, setIsReadySubmitted] = useState(false)
+  const roomDetailsQuery = usePvPRoomDetails(accessToken, roomId, {
+    enabled: !isInvalidRoomId,
+  })
+  const roomDetailsFromServer = roomDetailsQuery.data
 
-  // RoomList에서 join 결과를 캐시에 넣어주므로 매칭 페이지에서는 캐시만 읽는다.
-  // enabled:false로 네트워크 재호출 없이 캐시 데이터만 조회한다.
-  const roomJoinQuery = usePvPRoomJoinQuery(accessToken, roomId, { enabled: false })
-  // 쿼리 성공 시 실제 room 상세 데이터만 꺼낸다.
+  const isHostUser = hasMyUserId && roomDetailsFromServer?.host.id === myUserId
+  const isGuestUser = hasMyUserId && roomDetailsFromServer?.guest?.id === myUserId
+
+  let shouldAttemptJoinRoom = false
+  if (accessToken && hasMyUserId && roomDetailsFromServer && !isHostUser && !isGuestUser) {
+    shouldAttemptJoinRoom =
+      roomDetailsFromServer.status === OPEN_ROOM_STATUS && roomDetailsFromServer.guest === null
+  }
+
+  const roomJoinQuery = usePvPRoomJoinQuery(accessToken, roomId, {
+    enabled: shouldAttemptJoinRoom,
+  })
   const joinedRoomDetails = roomJoinQuery.data?.ok ? roomJoinQuery.data.data : null
-  const joinedRoomId = joinedRoomDetails?.room.id ?? null
+  const resolvedRoomDetails = joinedRoomDetails ?? roomDetailsFromServer ?? null
+  const joinedRoomId = resolvedRoomDetails?.room.id ?? null
+
+  let isParticipantUser = false
+  if (hasMyUserId && resolvedRoomDetails) {
+    isParticipantUser =
+      resolvedRoomDetails.host.id === myUserId || resolvedRoomDetails.guest?.id === myUserId
+  }
+  const participantRoomId = isParticipantUser ? joinedRoomId : null
+
+  const isProfileLoading = shouldFetchMyProfile && myProfileQuery.isLoading
+  const isRoomLoading = roomDetailsQuery.isLoading
+  const isJoinLoading = shouldAttemptJoinRoom && roomJoinQuery.isLoading
+
+  const [isStartingRecordingRequest, setIsStartingRecordingRequest] = useState(false)
+  const [isReadySubmitted, setIsReadySubmitted] = useState(false)
   const hasRoutedToFeedbackRef = useRef(false)
 
-  // 매칭 페이지 실시간 소켓 상태를 구독
   const {
-    // 서버 브로드캐스트 기반의 실시간 방 상태
     liveRoomStatus,
     thinkingKeywordName,
     thinkingEndsAtMs,
@@ -71,7 +96,7 @@ export function PvPMatchingPage() {
     cleanupMatchingConnection,
   } = usePvPMatchingSocket({
     accessToken,
-    joinedRoomId,
+    joinedRoomId: participantRoomId,
     myUserId,
     onSelfReady: () => {
       setIsReadySubmitted(true)
@@ -85,25 +110,22 @@ export function PvPMatchingPage() {
       }
     },
   })
-  const latestRoomStatus = liveRoomStatus ?? joinedRoomDetails?.status ?? null
-  const isFinishedStatus = latestRoomStatus === FINISHED_ROOM_STATUS
-
-  // 녹음 컨트롤러가 참고할 상태: 실시간 상태 우선, 없으면 초기 room 상태
-  const roomStatusForController = latestRoomStatus
 
   const { isExitAlertOpen, handleBack, handleExitConfirm, handleExitCancel, setIsExitAlertOpen } =
     usePvPMatchingExitGuard({
       accessToken,
-      joinedRoomId,
+      joinedRoomId: participantRoomId,
       cleanupMatchingConnection,
     })
+
+  const latestRoomStatus = liveRoomStatus ?? resolvedRoomDetails?.status ?? null
+  const isFinishedStatus = latestRoomStatus === FINISHED_ROOM_STATUS
 
   const {
     isRecording,
     isPaused,
     elapsedSeconds,
     recordedBlob,
-    // 현재 단계/상태에서 마이크 클릭 가능한지
     isMicInteractionAllowed,
     isSubmittingSubmission,
     isSubmissionCompleted,
@@ -111,15 +133,15 @@ export function PvPMatchingPage() {
     handlePvPMicClick,
   } = usePvPRecordController({
     accessToken,
-    roomId: joinedRoomId ?? null,
-    roomStatus: roomStatusForController,
+    roomId: participantRoomId,
+    roomStatus: latestRoomStatus,
   })
 
   useEffect(() => {
     if (!isFinishedStatus) return
     if (hasRoutedToFeedbackRef.current) return
 
-    const targetRoomId = joinedRoomId ?? roomId
+    const targetRoomId = participantRoomId ?? roomId
     if (!targetRoomId || Number.isNaN(targetRoomId)) return
 
     hasRoutedToFeedbackRef.current = true
@@ -130,67 +152,69 @@ export function PvPMatchingPage() {
     }
 
     void moveToFeedbackPage()
-  }, [cleanupMatchingConnection, isFinishedStatus, joinedRoomId, roomId, router])
+  }, [cleanupMatchingConnection, isFinishedStatus, participantRoomId, roomId, router])
 
   if (isInvalidRoomId) {
     return <StatusMessage message={INVALID_ROOM_ID_MESSAGE} />
   }
 
-  // join 캐시가 없거나 에러면 매칭 페이지를 진행할 수 없으므로 에러 메시지 렌더
-  if (roomJoinQuery.isError || roomJoinQuery.data?.ok === false || !roomJoinQuery.data) {
+  if (isProfileLoading || isRoomLoading || isJoinLoading) {
+    return <StatusMessage message={LOADING_MESSAGE} />
+  }
+
+  if (roomDetailsQuery.isError || !roomDetailsFromServer) {
     return <StatusMessage message={ERROR_MESSAGE} />
   }
 
-  const roomDetails = roomJoinQuery.data.data
+  if (shouldAttemptJoinRoom && (roomJoinQuery.isError || roomJoinQuery.data?.ok === false)) {
+    return <StatusMessage message={ERROR_MESSAGE} />
+  }
 
-  // UI 표시용 상태: 실시간 상태 우선, 없으면 초기 상태
-  const roomStatusForDisplay = liveRoomStatus ?? roomDetails.status
-  // 헤더 step/녹음 단계 판별
+  if (!resolvedRoomDetails || !isParticipantUser) {
+    return <StatusMessage message={ROOM_ACCESS_DENIED_MESSAGE} />
+  }
+
+  const roomStatusForDisplay = liveRoomStatus ?? resolvedRoomDetails.status
   const isRecordingStep = roomStatusForDisplay === RECORDING_ROOM_STATUS
   const isProcessingStep = roomStatusForDisplay === PROCESSING_ROOM_STATUS
+  const isHostWaitingOpenState =
+    roomStatusForDisplay === OPEN_ROOM_STATUS && resolvedRoomDetails.host.id === myUserId
+  const shouldRenderBattleUi = !isHostWaitingOpenState
   const isHeaderBackDisabled =
     roomStatusForDisplay === RECORDING_ROOM_STATUS ||
     roomStatusForDisplay === PROCESSING_ROOM_STATUS ||
     roomStatusForDisplay === FINISHED_ROOM_STATUS
 
-  const keywordNameForDisplay = thinkingKeywordName ?? roomDetails.keyword?.name ?? ''
+  const keywordNameForDisplay = thinkingKeywordName ?? resolvedRoomDetails.keyword?.name ?? ''
   const isThinkingStep = roomStatusForDisplay === THINKING_ROOM_STATUS
   const shouldShowFeedbackLoader =
     isSubmittingSubmission || isSubmissionCompleted || isProcessingStep || isFinishedStatus
 
-  // 준비 버튼 활성 조건:
-  // THINKING 상태 + 토큰/roomId 존재 + start-recording 요청 중 아님 + 아직 준비 누르지 않음
   const canStartPvPRecording =
     isThinkingStep &&
     Boolean(accessToken) &&
-    Boolean(joinedRoomId) &&
+    Boolean(participantRoomId) &&
     !isStartingRecordingRequest &&
     !isReadySubmitted
 
-  // 준비 버튼 클릭 핸들러
   const handleReadyButtonClick = async () => {
-    if (!accessToken || !joinedRoomId) return
+    if (!accessToken || !participantRoomId) return
     if (isReadySubmitted || isStartingRecordingRequest) return
 
     setIsReadySubmitted(true)
     setIsStartingRecordingRequest(true)
-    // 서버에 RECORDING 시작 요청
-    const startRecordingResult = await startPvPRecording(accessToken, joinedRoomId)
-    // 요청 종료 후 로딩 해제
+    const startRecordingResult = await startPvPRecording(accessToken, participantRoomId)
     setIsStartingRecordingRequest(false)
 
-    // 실패하면 제출 상태를 롤백하고 에러 토스트 표시
     if (!startRecordingResult.ok) {
       setIsReadySubmitted(false)
       toast.error(START_RECORDING_ERROR_MESSAGE)
       return
     }
 
-    // 성공 시 서버 응답 status를 즉시 반영해 UI 지연을 줄인다.
     setLiveRoomStatus(startRecordingResult.data.status)
   }
 
-  // 매칭 페이지 UI 렌더
   return (
     <div className="flex h-full w-full flex-col gap-4">
       <ModeHeader
@@ -199,50 +223,67 @@ export function PvPMatchingPage() {
         onBack={handleBack}
         backDisabled={isHeaderBackDisabled}
       />
-      <PvPCategory categoryName={roomDetails.category.name} />
-      <PvPParticipants
-        leftProfile={{
-          name: roomDetails.host.nickname,
-          avatarUrl: roomDetails.host.profileImageUrl,
-        }}
-        rightProfile={{
-          name: roomDetails.guest?.nickname ?? EMPTY_GUEST_NAME,
-          avatarUrl: roomDetails.guest?.profileImageUrl ?? '',
-        }}
-      />
-      <PvPKeyword keywordName={keywordNameForDisplay} />
-      <PvPThinkingCountdown
-        isThinkingStep={isThinkingStep}
-        thinkingEndsAtMs={thinkingEndsAtMs}
-      />
-      {shouldShowFeedbackLoader ? (
-        <FeedbackLoader status={isProcessingStep ? 'PROCESSING' : 'PENDING'} />
-      ) : (
-        <MicrophoneBox
-          onMicClick={() => {
-            void handlePvPMicClick()
+      <PvPCategory categoryName={resolvedRoomDetails.category.name} />
+      {isHostWaitingOpenState ? (
+        <PvPMatchingWaiting
+          leftProfile={{
+            name: resolvedRoomDetails.host.nickname,
+            avatarUrl: resolvedRoomDetails.host.profileImageUrl,
           }}
-          title="음성으로 말해보세요."
-          description="버튼을 눌러 녹음을 시작하세요."
-          errorMessage="녹음 시작에 실패했습니다."
-          isMicDisabled={Boolean(recordedBlob) || !isMicInteractionAllowed}
-          isRecording={isRecording}
-          isPaused={isPaused}
-          elapsedSeconds={elapsedSeconds}
+          rightProfile={{
+            name: resolvedRoomDetails.guest?.nickname ?? EMPTY_GUEST_NAME,
+            avatarUrl: resolvedRoomDetails.guest?.profileImageUrl ?? '',
+          }}
+        />
+      ) : (
+        <PvPParticipants
+          leftProfile={{
+            name: resolvedRoomDetails.host.nickname,
+            avatarUrl: resolvedRoomDetails.host.profileImageUrl,
+          }}
+          rightProfile={{
+            name: resolvedRoomDetails.guest?.nickname ?? EMPTY_GUEST_NAME,
+            avatarUrl: resolvedRoomDetails.guest?.profileImageUrl ?? '',
+          }}
         />
       )}
-      <RecordTipBox />
-      <div className="mb-6 flex w-full items-center justify-center">
-        <Button
-          variant="record_confirm_btn"
-          onClick={() => {
-            void handleReadyButtonClick()
-          }}
-          disabled={!canStartPvPRecording}
-        >
-          준비
-        </Button>
-      </div>
+      {shouldRenderBattleUi ? (
+        <>
+          <PvPKeyword keywordName={keywordNameForDisplay} />
+          <PvPThinkingCountdown
+            isThinkingStep={isThinkingStep}
+            thinkingEndsAtMs={thinkingEndsAtMs}
+          />
+          {shouldShowFeedbackLoader ? (
+            <FeedbackLoader status={isProcessingStep ? 'PROCESSING' : 'PENDING'} />
+          ) : (
+            <MicrophoneBox
+              onMicClick={() => {
+                void handlePvPMicClick()
+              }}
+              title="음성으로 말해보세요."
+              description="버튼을 눌러 녹음을 시작하세요."
+              errorMessage="녹음 시작에 실패했습니다."
+              isMicDisabled={Boolean(recordedBlob) || !isMicInteractionAllowed}
+              isRecording={isRecording}
+              isPaused={isPaused}
+              elapsedSeconds={elapsedSeconds}
+            />
+          )}
+          <RecordTipBox />
+          <div className="mb-6 flex w-full items-center justify-center">
+            <Button
+              variant="record_confirm_btn"
+              onClick={() => {
+                void handleReadyButtonClick()
+              }}
+              disabled={!canStartPvPRecording}
+            >
+              준비
+            </Button>
+          </div>
+        </>
+      ) : null}
       <AlertModal
         open={isExitAlertOpen}
         onOpenChange={setIsExitAlertOpen}

--- a/src/features/pvp/model/usePvPMatchingCreateFlow.ts
+++ b/src/features/pvp/model/usePvPMatchingCreateFlow.ts
@@ -1,233 +1,182 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
-import { createPvPRoom, exitPvPRoom } from '@/entities/room'
+import { createPvPRoom } from '@/entities/room'
 import { useAccessToken } from '@/features/auth'
 
-import { usePvPRoomTopicSocket } from './usePvPRoomTopicSocket'
-
-import type { PvpSocketMessage } from './pvpSocketMessage'
 import type { CategoryItemType } from '@/entities/category'
 
-const ROOM_JOINED_MESSAGE_TYPE = 'ROOM_JOINED'
-const ROOM_LEFT_MESSAGE_TYPE = 'ROOM_LEFT'
-const STATUS_CHANGE_MESSAGE_TYPE = 'STATUS_CHANGE'
-
-const EXIT_ROOM_ERROR_MESSAGE = '방을 나가던 중 오류가 발생하였습니다.'
 const CREATE_ROOM_ERROR_MESSAGE = '방을 만들던 중 오류가 발생하였습니다.'
-const UNREGISTER_SESSION_ACTION = 'unregister-session'
+const MATCHING_PATH_PREFIX = '/pvp/matching'
 
 const normalizeRoomNameBoundarySpaces = (value: string) => value.trim()
 
-// 소켓 payload(data)에서 status 문자열을 안전하게 추출한다.
-const getStatusFromMessageData = (data: PvpSocketMessage['data']) => {
-  const status = data?.status
-  return typeof status === 'string' ? status : null
-}
-
-// 훅 입력 파라미터
 type UsePvPMatchingCreateFlowParams = {
-  // 상위(페이지)에서 "뒤로가기 가드 활성 여부"를 동기화할 때 사용
-  onExitGuardChange?: (isActive: boolean) => void
+  onCreatingRoomChange?: (isCreatingRoom: boolean) => void
+  onBackHandlerChange?: (onBackHandler: () => void) => void
+  onExitConfirm?: () => void
 }
 
-// 훅 반환 타입
 type UsePvPMatchingCreateFlowResult = {
   selectedCategory: CategoryItemType | null
   // 카테고리 단계 -> 방 이름 단계 전환 여부
   isNextClicked: boolean | null
-  // 방 생성 후 상대 대기 상태 여부
-  isWaiting: boolean
-  // 상대가 들어와 매칭 완료된 상태 여부
-  isComplete: boolean
-  // 입력 중인 방 이름
+  isCategoryStep: boolean
   roomName: string
+  isCreatingRoom: boolean
   isCreateButtonDisabled: boolean
-  createButtonVariant: 'category' | 'create' | 'waiting' | 'complete'
+  createButtonVariant: 'category' | 'create'
   handleCategorySelect: (category: CategoryItemType) => void
   handleRoomNameChange: (value: string) => void
   handleRoomNameBlur: () => void
+  handleBackClick: () => void
   handleCreateButtonClick: () => Promise<void>
   handleExitConfirm: () => Promise<boolean>
+  handleAlertExitConfirm: () => Promise<void>
 }
 
 export function usePvPMatchingCreateFlow({
-  onExitGuardChange,
-}: UsePvPMatchingCreateFlowParams): UsePvPMatchingCreateFlowResult {
+  onCreatingRoomChange,
+  onBackHandlerChange,
+  onExitConfirm,
+}: UsePvPMatchingCreateFlowParams = {}): UsePvPMatchingCreateFlowResult {
+  // 사용자가 선택한 카테고리(1단계)
   const [selectedCategory, setSelectedCategory] = useState<CategoryItemType | null>(null)
-  // 1단계(카테고리) -> 2단계(방 이름) 전환 state
+  // 1단계(카테고리)에서 2단계(방 이름 입력)로 넘어갔는지 표시
   const [isNextClicked, setIsNextClicked] = useState<boolean | null>(null)
-
-  const [isWaiting, setIsWaiting] = useState(false)
-  const [isComplete, setIsComplete] = useState(false)
+  // 방 이름 입력값(2단계)
   const [roomName, setRoomName] = useState('')
-  // 현재 소켓 연결/제어에 사용할 roomId state (없으면 null)
-  const [currentRoomId, setCurrentRoomId] = useState<number | null>(null)
+  // createPvPRoom 요청 진행 상태 (중복 클릭 방지 + UI 비활성화 용도)
+  const [isCreatingRoom, setIsCreatingRoom] = useState(false)
 
   const router = useRouter()
   const accessToken = useAccessToken()
 
-  // /topic/pvp/{roomId} 메시지 처리 콜백
-  const handleTopicMessage = useCallback(
-    (message: PvpSocketMessage) => {
-      // 게스트가 입장하면 대기 -> 완료 상태로 전환
-      if (message.type === ROOM_JOINED_MESSAGE_TYPE) {
-        setIsWaiting(false)
-        setIsComplete(true)
-        return
-      }
-
-      // 게스트가 나가면 완료 -> 대기 상태로 되돌림
-      if (message.type === ROOM_LEFT_MESSAGE_TYPE) {
-        setIsComplete(false)
-        setIsWaiting(true)
-        return
-      }
-
-      // STATUS_CHANGE가 아니면 무시한다.
-      if (message.type !== STATUS_CHANGE_MESSAGE_TYPE) return
-
-      // payload에서 status를 꺼낸다.
-      const roomStatus = getStatusFromMessageData(message.data)
-      if (!roomStatus) return
-
-      if (roomStatus === 'OPEN') {
-        setIsComplete(false)
-        setIsWaiting(true)
-        return
-      }
-
-      if (roomStatus === 'MATCHED') {
-        setIsWaiting(false)
-        setIsComplete(true)
-        router.replace(`/pvp/matching/${message.roomId}`)
-      }
-    },
-    [router],
-  )
-
-  // 공통 room-topic 소켓 훅으로 연결/구독/publish/정리를 위임
-  const { cleanupConnection, publishRoomAction } = usePvPRoomTopicSocket({
-    accessToken,
-    roomId: currentRoomId,
-    onTopicMessage: handleTopicMessage,
-  })
-
-  // 대기/완료 상태에 따라 상위의 "이탈 가드" 상태를 동기화
-  useEffect(() => {
-    if (onExitGuardChange) {
-      // waiting 또는 complete인 동안에는 이탈 가드를 활성화
-      onExitGuardChange(isWaiting || isComplete)
-    }
-  }, [isComplete, isWaiting, onExitGuardChange])
-
-  // 카테고리 선택 여부를 boolean으로 만든다.
+  // 1단계 유효성: 카테고리가 선택되었는지
   const hasSelectedCategory = Boolean(selectedCategory)
-  // 아직 "다음" 전이면 카테고리 단계다.
+  // 아직 "다음"을 누르지 않았으면 카테고리 단계
   const isCategoryStep = !isNextClicked
 
-  const createButtonVariant = useMemo(() => {
-    if (isCategoryStep) return 'category'
-    if (isComplete) return 'complete'
-    if (isWaiting) return 'waiting'
-    return 'create'
-  }, [isCategoryStep, isComplete, isWaiting])
+  // 버튼 라벨/의미는 현재 단계에 맞춰 category -> create 로만 사용
+  const createButtonVariant = isCategoryStep ? 'category' : 'create'
 
-  // 단계별 필수 입력값 검증 (카테고리 또는 방 이름)
+  // 단계별 필수 입력값 검증:
+  // - 1단계: 카테고리 필수
+  // - 2단계: trim 기준 방 이름 필수
   const isFormInvalid = isCategoryStep ? !hasSelectedCategory : roomName.trim().length === 0
-  // 대기/완료 상태에서는 다시 생성 동작을 잠근다.
-  const isMatchingLocked = createButtonVariant === 'waiting' || createButtonVariant === 'complete'
-  // 최종 버튼 비활성 조건
-  const isCreateButtonDisabled = isFormInvalid || isMatchingLocked
+  // 최종 버튼 비활성 조건 (입력 미완료 또는 생성 요청 진행 중)
+  const isCreateButtonDisabled = isFormInvalid || isCreatingRoom
 
-  // 카테고리 선택/해제 토글 핸들러
-  const handleCategorySelect = (category: CategoryItemType) => {
+  const handleCategorySelect = useCallback((category: CategoryItemType) => {
     setSelectedCategory((prev) => (prev?.id === category.id ? null : category))
-  }
+  }, [])
 
-  const handleRoomNameChange = (value: string) => {
+  const handleRoomNameChange = useCallback((value: string) => {
     setRoomName(value)
-  }
+  }, [])
 
-  const handleRoomNameBlur = () => {
+  const handleRoomNameBlur = useCallback(() => {
     setRoomName((prev) => normalizeRoomNameBoundarySpaces(prev))
-  }
+  }, [])
+
+  // 뒤로가기 규칙:
+  // 1) 카테고리 미선택 -> /pvp 이동
+  // 2) 카테고리 선택 + 방 이름 미입력 -> 카테고리 선택 해제
+  // 3) 카테고리 선택 + 방 이름 입력 -> 방 이름 + 카테고리 선택 모두 초기화
+  const handleBackClick = useCallback(() => {
+    if (isCreatingRoom) return
+
+    if (!selectedCategory) {
+      router.replace('/pvp')
+      return
+    }
+
+    if (roomName.trim().length === 0) {
+      setSelectedCategory(null)
+      setIsNextClicked(null)
+      router.replace('/pvp')
+      return
+    }
+
+    setRoomName('')
+    setSelectedCategory(null)
+    setIsNextClicked(null)
+  }, [isCreatingRoom, roomName, router, selectedCategory])
+
+  // 부모 페이지와 생성 진행 상태를 동기화한다.
+  useEffect(() => {
+    onCreatingRoomChange?.(isCreatingRoom)
+  }, [isCreatingRoom, onCreatingRoomChange])
+
+  // 부모 페이지 헤더가 사용할 뒤로가기 핸들러를 등록한다.
+  useEffect(() => {
+    onBackHandlerChange?.(handleBackClick)
+  }, [handleBackClick, onBackHandlerChange])
 
   // "다음/방 만들기" 클릭 핸들러
   const handleCreateButtonClick = async () => {
-    // 1단계에서는 2단계(방 이름 입력)로만 전환하고 종료
+    // 1단계에서는 API 호출 없이 2단계 UI로만 전환
     if (!isNextClicked) {
       setIsNextClicked(true)
       return
     }
 
+    // 2단계에서 필수 선행값이 없으면 요청하지 않는다.
     if (!accessToken || !selectedCategory) return
 
+    // 서버에 보낼 값은 앞/뒤 공백을 제거한 방 이름으로 정규화
     const normalizedRoomName = normalizeRoomNameBoundarySpaces(roomName)
     if (normalizedRoomName.length === 0) return
 
+    if (isCreatingRoom) return
+
+    // 요청 시작 시 즉시 비활성화
+    setIsCreatingRoom(true)
+
+    // 방 생성 API 호출
     const createdRoom = await createPvPRoom(accessToken, {
       categoryId: selectedCategory.id,
       roomName: normalizedRoomName,
     })
 
+    // 생성 실패 시 라우팅하지 않고 사용자에게 오류를 알린다.
     if (!createdRoom) {
       toast.error(CREATE_ROOM_ERROR_MESSAGE)
+      setIsCreatingRoom(false)
       return
     }
 
-    setCurrentRoomId(createdRoom.room.id)
-
-    // 서버 상태가 OPEN이면 상대 입장 전 대기 상태를 켠다.
-    if (createdRoom.status === 'OPEN' && !isWaiting) {
-      setIsWaiting(true)
-    }
+    // 2안: 생성 직후 대기 페이지를 거치지 않고 매칭 페이지로 즉시 이동
+    router.replace(`${MATCHING_PATH_PREFIX}/${createdRoom.room.id}`)
   }
 
-  const handleExitConfirm = async () => {
-    const roomId = currentRoomId
-
-    if (roomId) {
-      if (!accessToken) {
-        toast.error(EXIT_ROOM_ERROR_MESSAGE)
-        return false
-      }
-
-      const isExited = await exitPvPRoom(accessToken, roomId)
-      if (!isExited) {
-        toast.error(EXIT_ROOM_ERROR_MESSAGE)
-        return false
-      }
-
-      // 방 나가기 성공 후 세션 해제 이벤트를 서버에 보낸다.
-      publishRoomAction(roomId, UNREGISTER_SESSION_ACTION, JSON.stringify({}))
-    }
-
-    // 소켓 구독/연결 정리
-    await cleanupConnection()
-    // 로컬 room/session 상태 초기화
-    setCurrentRoomId(null)
-    setIsWaiting(false)
-    setIsComplete(false)
-
+  const handleExitConfirm = useCallback(async () => {
     return true
-  }
+  }, [])
+
+  const handleAlertExitConfirm = useCallback(async () => {
+    const isExitSuccess = await handleExitConfirm()
+    if (!isExitSuccess) return
+    onExitConfirm?.()
+  }, [handleExitConfirm, onExitConfirm])
 
   return {
     selectedCategory,
     isNextClicked,
-    isWaiting,
-    isComplete,
+    isCategoryStep,
     roomName,
+    isCreatingRoom,
     isCreateButtonDisabled,
     createButtonVariant,
     handleCategorySelect,
     handleRoomNameChange,
     handleRoomNameBlur,
+    handleBackClick,
     handleCreateButtonClick,
     handleExitConfirm,
+    handleAlertExitConfirm,
   }
 }

--- a/src/features/pvp/model/usePvPRoomCreateExitGuard.ts
+++ b/src/features/pvp/model/usePvPRoomCreateExitGuard.ts
@@ -8,28 +8,20 @@ type PvPRoomCreateExitGuardResult = {
   handleBack: () => void
   handleExitConfirm: () => void
   handleExitCancel: () => void
-  handleWaitingChange: (waiting: boolean) => void
   setIsExitAlertOpen: (open: boolean) => void
 }
 
-/* 
-  PvP 룸 exit guard
-  - 매칭 상대 대기 중이 아닐 때 -> 바로 뒤로 가기
-  - 매칭 상대 대기 중 | 매칭 완료 시 -> 나가기 모달
-    - 나가기 클릭 -> /pvp로 이동
-    - 계속하기 클릭 -> 모달 꺼짐
+/*
+  PvP 룸 생성 페이지 exit guard
+  - 현재 구조에서는 뒤로가기 시 이전 페이지로 즉시 이동
+  - AlertModal 상태는 외부 제어와의 호환을 위해 유지
 */
 export function usePvPRoomCreateExitGuard(): PvPRoomCreateExitGuardResult {
-  // 뒤로가기 모달 상태와 활성 여부
+  // 뒤로가기 모달 상태
   const [isExitAlertOpen, setIsExitAlertOpen] = useState(false)
-  const [isExitGuardActive, setIsExitGuardActive] = useState(false)
   const router = useRouter()
 
   const handleBack = () => {
-    if (isExitGuardActive) {
-      setIsExitAlertOpen(true)
-      return
-    }
     router.back()
   }
 
@@ -42,17 +34,11 @@ export function usePvPRoomCreateExitGuard(): PvPRoomCreateExitGuardResult {
     setIsExitAlertOpen(false)
   }
 
-  const handleWaitingChange = (waiting: boolean) => {
-    // 매칭 진행/완료 여부를 Exit Guard에 반영
-    setIsExitGuardActive(waiting)
-  }
-
   return {
     isExitAlertOpen,
     handleBack,
     handleExitConfirm,
     handleExitCancel,
-    handleWaitingChange,
     setIsExitAlertOpen,
   }
 }

--- a/src/features/pvp/ui/RoomCreateButton.tsx
+++ b/src/features/pvp/ui/RoomCreateButton.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-
 import { Button } from '@/shared'
 
 type RoomCreateButtonVariant = 'category' | 'create' | 'waiting' | 'complete'
@@ -26,22 +24,7 @@ const ENABLED_CREATE_BUTTON_TONE_CLASSNAME =
   'bg-primary text-primary-foreground hover:bg-primary/90'
 
 export function RoomCreateButton({ variant, disabled, onClick }: RoomCreateButtonProps) {
-  const [currentVariant, setCurrentVariant] = useState<RoomCreateButtonVariant>(variant)
-
-  useEffect(() => {
-    setCurrentVariant(variant)
-  }, [variant])
-
-  const handleClick = () => {
-    if (currentVariant === 'create') {
-      setCurrentVariant('waiting')
-    }
-    if (onClick) {
-      onClick()
-    }
-  }
-
-  const isCreateActionEnabled = currentVariant === 'create' && !disabled
+  const isCreateActionEnabled = variant === 'create' && !disabled
   const buttonToneClassName = isCreateActionEnabled
     ? ENABLED_CREATE_BUTTON_TONE_CLASSNAME
     : DEFAULT_BUTTON_TONE_CLASSNAME
@@ -51,9 +34,9 @@ export function RoomCreateButton({ variant, disabled, onClick }: RoomCreateButto
       <Button
         className={`${BUTTON_SIZE_CLASSNAME} ${buttonToneClassName}`}
         disabled={disabled}
-        onClick={handleClick}
+        onClick={onClick}
       >
-        {LABEL_BY_VARIANT[currentVariant]}
+        {LABEL_BY_VARIANT[variant]}
       </Button>
     </div>
   )

--- a/src/widgets/pvp-matching-create/ui/PvPMatchingCreate.tsx
+++ b/src/widgets/pvp-matching-create/ui/PvPMatchingCreate.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useProfile } from '@/entities/user'
 import { useAccessToken } from '@/features/auth'
 import {
-  PvPMatchingWaiting,
   RoomCategorySelect,
   RoomCreateButton,
   RoomNameSetting,
@@ -12,7 +10,8 @@ import {
 import { AlertModal } from '@/shared'
 
 type PvPMatchingCreateProps = {
-  onExitGuardChange?: (isActive: boolean) => void
+  onCreatingRoomChange?: (isCreatingRoom: boolean) => void
+  onBackHandlerChange?: (onBackHandler: () => void) => void
   isExitAlertOpen?: boolean
   onExitAlertOpenChange?: (open: boolean) => void
   onExitConfirm?: () => void
@@ -20,21 +19,19 @@ type PvPMatchingCreateProps = {
 }
 
 export function PvPMatchingCreate({
-  onExitGuardChange,
+  onCreatingRoomChange,
+  onBackHandlerChange,
   isExitAlertOpen,
   onExitAlertOpenChange,
   onExitConfirm,
   onExitCancel,
 }: PvPMatchingCreateProps) {
   const accessToken = useAccessToken()
-  const profile = useProfile()
 
-  // 매칭 생성 플로우 상태/핸들러(카테고리 선택 → 방 생성 → 대기/완료)
+  // 매칭 생성 플로우 상태/핸들러(카테고리 선택 -> 방 이름 입력 -> 생성 후 매칭 페이지 이동)
   const {
     selectedCategory,
-    isNextClicked,
-    isWaiting,
-    isComplete,
+    isCategoryStep,
     roomName,
     isCreateButtonDisabled,
     createButtonVariant,
@@ -42,20 +39,12 @@ export function PvPMatchingCreate({
     handleRoomNameChange,
     handleRoomNameBlur,
     handleCreateButtonClick,
-    handleExitConfirm: handleSocketExitConfirm,
-  } = usePvPMatchingCreateFlow({ onExitGuardChange })
-
-  // 단계 분기 (카테고리 선택 단계 여부)
-  const isCategoryStep = isNextClicked === null
-
-  // 매칭 상태 표시 여부 (대기 또는 완료)
-  const shouldShowMatchingStatus = isWaiting || isComplete
-
-  const handleAlertExitConfirm = async () => {
-    const isExitSuccess = await handleSocketExitConfirm()
-    if (!isExitSuccess) return
-    onExitConfirm?.()
-  }
+    handleAlertExitConfirm,
+  } = usePvPMatchingCreateFlow({
+    onCreatingRoomChange,
+    onBackHandlerChange,
+    onExitConfirm,
+  })
 
   return (
     <div className="flex w-full flex-1 flex-col">
@@ -66,25 +55,12 @@ export function PvPMatchingCreate({
           onCategorySelect={handleCategorySelect}
         />
       ) : (
-        <>
-          <RoomNameSetting
-            selectedCategoryName={selectedCategory?.categoryName}
-            roomName={roomName}
-            onRoomNameChange={handleRoomNameChange}
-            onRoomNameBlur={handleRoomNameBlur}
-            disabled={isWaiting || isComplete}
-          />
-          {shouldShowMatchingStatus ? (
-            <PvPMatchingWaiting
-              leftProfile={{
-                name: profile.nickname,
-                avatarUrl: profile.profileImageUrl,
-              }}
-              rightProfile={{ name: '...' }}
-              showSpinner={!isComplete}
-            />
-          ) : null}
-        </>
+        <RoomNameSetting
+          selectedCategoryName={selectedCategory?.categoryName}
+          roomName={roomName}
+          onRoomNameChange={handleRoomNameChange}
+          onRoomNameBlur={handleRoomNameBlur}
+        />
       )}
       <RoomCreateButton
         variant={createButtonVariant}


### PR DESCRIPTION
## 개요
* PvP **방 생성 플로우를 “생성 완료 → 즉시 `/pvp/matching/{roomId}` 이동”** 구조로 정리했습니다
* `PvPMatchingCreate`에 있던 오케스트레이션 로직(뒤로가기/생성중 상태/exit action)을 `usePvPMatchingCreateFlow`로 올려 **책임을 훅으로 수렴**
* 생성 중 UX 안정화를 위해 **방 만들기 버튼 및 헤더 뒤로가기 비활성화**, 매칭 페이지에서 **`OPEN + HOST` 상태는 대기 UI만 노출**하도록 분기
* 생성 페이지 뒤로가기 규칙을 복원했고, `RoomCreateButton`은 상위 `variant`로 제어하는 형태로 정리

---

## 변경사항
### 1) 생성 플로우 개편: create 후 즉시 matching으로 이동
* 방 생성 완료 시 `/pvp/matching/{roomId}`로 즉시 이동하도록 흐름 정리
* 생성 이후 `OPEN + HOST` 상태에서는 **대기 UI(PvPMatchingWaiting)만 렌더**하고 전투 UI(키워드/마이크/준비 버튼 등)는 숨김 처리

### 2) 오케스트레이션 로직 훅 수렴
* `PvPMatchingCreate`의
  * 뒤로가기 핸들러 연결
  * 생성중 상태 동기화
  * exit action
    을 `usePvPMatchingCreateFlow`로 이동해 컴포넌트는 UI 중심으로 단순화

### 3) 생성 중 UX 가드
* 방 생성 중에는
  * `방 만들기` 버튼 비활성화
  * 헤더 뒤로가기 비활성화
    로 중복 생성/이탈로 인한 상태 꼬임 방지

### 4) 생성 페이지 뒤로가기 규칙 복원
* 카테고리 미선택: `/pvp` 이동
* 카테고리 선택 + 방 이름 미입력: **카테고리 해제 + /pvp 이동**
* 카테고리 선택 + 방 이름 입력: **방 이름 + 카테고리 모두 해제**

### 5) RoomCreateButton 정리
* `RoomCreateButton`을 **상위 `variant`로 제어**하는 방식으로 구조 정리

---

## Screenshots (UI 변경 시)
* PvP 방 생성 → 생성 완료 후 `/pvp/matching/{roomId}`로 즉시 이동(before/after)
* `OPEN + HOST` 상태에서 대기 UI만 노출되고 전투 UI가 숨겨지는 화면(before/after)
* 생성 중 버튼/뒤로가기 비활성화 상태(before/after)
* 뒤로가기 규칙(3 케이스) 동작 확인 캡처(선택)

---

## How to test

1. 설치/실행 및 검증

   * `pnpm i`
   * `pnpm lint`
   * `pnpm build`
   * `pnpm dev`

2. 방 생성 플로우 확인

   * `/pvp/create` 진입
   * 카테고리 선택 → 방 이름 입력 → 방 생성
   * 생성 완료 후 **즉시 `/pvp/matching/{roomId}`로 이동**되는지 확인

3. 매칭 페이지 UI 분기 확인

   * `OPEN + HOST` 상태일 때:

     * `PvPMatchingWaiting`만 렌더되는지 확인
     * `PvPKeyword / Microphone / 준비 버튼` 등 전투 UI가 숨겨지는지 확인

4. 생성 중 UX 가드 확인

   * 방 생성 요청 중:

     * `방 만들기` 버튼이 비활성화되는지
     * 헤더 뒤로가기가 비활성화되는지 확인

5. 뒤로가기 규칙(생성 페이지) 확인

   * 카테고리 미선택 상태에서 뒤로가기 → `/pvp` 이동
   * 카테고리 선택 + 방 이름 미입력에서 뒤로가기 → 카테고리 해제
   * 카테고리 선택 + 방 이름 입력에서 뒤로가기 → 방 이름/카테고리 모두 해제

---

## 참고 커밋

* `990e61b` feat: refine pvp create flow and matching open state ui
