### PR TITLE
fix: remove duplicate submissoins call

### DIFF
--- a/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
+++ b/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
@@ -72,6 +72,7 @@ export function PvPMatchingPage() {
   const joinedRoomDetails = roomJoinQuery.data?.ok ? roomJoinQuery.data.data : null
   const resolvedRoomDetails = joinedRoomDetails ?? roomDetailsFromServer ?? null
   const joinedRoomId = resolvedRoomDetails?.room.id ?? null
+  const socketRoomId = joinedRoomId
 
   let isParticipantUser = false
   if (hasMyUserId && resolvedRoomDetails) {
@@ -96,7 +97,7 @@ export function PvPMatchingPage() {
     cleanupMatchingConnection,
   } = usePvPMatchingSocket({
     accessToken,
-    joinedRoomId: participantRoomId,
+    joinedRoomId: socketRoomId,
     myUserId,
     onSelfReady: () => {
       setIsReadySubmitted(true)
@@ -133,7 +134,7 @@ export function PvPMatchingPage() {
     handlePvPMicClick,
   } = usePvPRecordController({
     accessToken,
-    roomId: participantRoomId,
+    roomId: socketRoomId,
     roomStatus: latestRoomStatus,
   })
 
@@ -193,17 +194,17 @@ export function PvPMatchingPage() {
   const canStartPvPRecording =
     isThinkingStep &&
     Boolean(accessToken) &&
-    Boolean(participantRoomId) &&
+    Boolean(socketRoomId) &&
     !isStartingRecordingRequest &&
     !isReadySubmitted
 
   const handleReadyButtonClick = async () => {
-    if (!accessToken || !participantRoomId) return
+    if (!accessToken || !socketRoomId) return
     if (isReadySubmitted || isStartingRecordingRequest) return
 
     setIsReadySubmitted(true)
     setIsStartingRecordingRequest(true)
-    const startRecordingResult = await startPvPRecording(accessToken, participantRoomId)
+    const startRecordingResult = await startPvPRecording(accessToken, socketRoomId)
     setIsStartingRecordingRequest(false)
 
     if (!startRecordingResult.ok) {

--- a/src/features/pvp/model/usePvPMatchingSocket.ts
+++ b/src/features/pvp/model/usePvPMatchingSocket.ts
@@ -15,6 +15,8 @@ const RECORDING_ROOM_STATUS = 'RECORDING'
 
 const WAIT_OPPONENT_READY_TOAST_MESSAGE = '상대방이 준비할 때까지 기다려주세요.'
 const OPPONENT_READY_TOAST_MESSAGE = '상대방이 준비되었습니다.'
+const READY_UPDATED_TOAST_MESSAGE = '준비 상태가 갱신되었습니다.'
+const ANSWER_SUBMITTED_UPDATED_TOAST_MESSAGE = '제출 상태가 갱신되었습니다.'
 
 // THINKING 종료 시각 ISO 문자열을 epoch ms로 변환한다.
 const parseThinkingEndsAtMs = (thinkingEndsAt: string | null) => {
@@ -85,7 +87,10 @@ export function usePvPMatchingSocket({
         const readyUserId = message.data.userId
 
         const currentMyUserId = myUserIdRef.current
-        if (!currentMyUserId) return
+        if (!currentMyUserId) {
+          toast.info(message.data.message ?? READY_UPDATED_TOAST_MESSAGE)
+          return
+        }
 
         if (readyUserId === currentMyUserId) {
           onSelfReady?.()
@@ -100,7 +105,10 @@ export function usePvPMatchingSocket({
       if (message.type === ANSWER_SUBMITTED_MESSAGE_TYPE) {
         const submittedUserId = message.data.userId
         const currentMyUserId = myUserIdRef.current
-        if (!currentMyUserId) return
+        if (!currentMyUserId) {
+          toast.info(message.data.message ?? ANSWER_SUBMITTED_UPDATED_TOAST_MESSAGE)
+          return
+        }
 
         if (submittedUserId === currentMyUserId) {
           onSelfAnswerSubmitted?.()

--- a/src/features/pvp/model/usePvPRecordController.ts
+++ b/src/features/pvp/model/usePvPRecordController.ts
@@ -70,6 +70,8 @@ export function usePvPRecordController({
   const isStartingLocalRecordingRef = useRef(false)
   // 제출(생성/업로드/완료) 중복 실행 방지 ref
   const isSubmittingRef = useRef(false)
+  // 한 번 제출이 시작되면 같은 녹음 결과에 대한 중복 제출을 막는다.
+  const hasSubmittedRef = useRef(false)
   // 제출 진행 상태(state)
   const [isSubmittingSubmission, setIsSubmittingSubmission] = useState(false)
   // 제출 완료 상태(state)
@@ -99,6 +101,10 @@ export function usePvPRecordController({
     // 시작 중이면 중복 시작하지 않는다.
     if (isStartingLocalRecordingRef.current) return
 
+    // 새 녹음 사이클 시작 시 제출 상태를 초기화한다.
+    hasSubmittedRef.current = false
+    setIsSubmissionCompleted(false)
+
     // 시작 중 플래그 on
     isStartingLocalRecordingRef.current = true
     try {
@@ -113,12 +119,14 @@ export function usePvPRecordController({
   // 제출 공통 플로우: submission 생성 -> 업로드 -> complete
   const submitRecordedBlob = useCallback(
     async (completedBlob: Blob) => {
-      if (isSubmittingRef.current) return
+      if (isSubmittingRef.current || hasSubmittedRef.current) return
 
       // 제출 중복 방지 플래그 on
       isSubmittingRef.current = true
+      hasSubmittedRef.current = true
       // UI 로더 표시 상태 on
       setIsSubmittingSubmission(true)
+      let shouldKeepSubmitted = false
       try {
         if (!accessToken || !roomId) {
           toast.error(CREATE_SUBMISSION_ERROR_MESSAGE)
@@ -168,9 +176,14 @@ export function usePvPRecordController({
 
         // complete 성공 시 로더 유지 상태로 전환
         setIsSubmissionCompleted(true)
+        shouldKeepSubmitted = true
       } finally {
         // 제출 중복 방지 플래그 off
         isSubmittingRef.current = false
+        // 실패한 경우에만 재시도를 허용한다.
+        if (!shouldKeepSubmitted) {
+          hasSubmittedRef.current = false
+        }
         // 제출 로딩 상태 off
         setIsSubmittingSubmission(false)
       }
@@ -213,9 +226,11 @@ export function usePvPRecordController({
     if (!autoStopped) return
     if (!recordedBlob) return
 
+    // auto-stop 플래그는 즉시 소비해 effect 재실행 중복을 막는다.
+    resetAutoStopped()
+
     const submitAfterAutoStop = async () => {
       await submitRecordedBlob(recordedBlob)
-      resetAutoStopped()
     }
 
     void submitAfterAutoStop()


### PR DESCRIPTION
## 개요

* PvP 매칭 녹음 플로우에서 `submissions`가 **중복 호출되는 문제**를 수정 #106 .
* `usePvPRecordController`의 제출 가드를 강화하고, auto-stop 경로에서 effect 재실행으로 인해 재제출되는 케이스를 차단
* 소켓 이벤트 처리(`PLAYER_READY`, `ANSWER_SUBMITTED`)는 사용자 식별 전에도 안전하게 토스트를 띄울 수 있도록 fallback을 추가
* 매칭 페이지에서 소켓/녹음 API가 참조하는 `roomId` 연결 타이밍을 보정

---

## 변경사항
* **중복 제출(duplicate submissions) 방지**
  * `usePvPRecordController`에서 중복 제출 가드 강화
  * auto-stop 흐름에서 effect 재실행에 의한 재제출 방지

* **소켓 이벤트 토스트 안정화**
  * `PLAYER_READY`, `ANSWER_SUBMITTED` 이벤트에서 사용자 식별 정보가 아직 없을 때도 토스트가 깨지지 않도록 fallback 처리

* **roomId 연결 타이밍 보정**
  * 매칭 페이지에서 소켓/녹음 API 대상 `roomId`가 늦게 연결되어 잘못된 호출이 발생하지 않도록 타이밍 조정

---

## Screenshots (UI 변경 시)

---

## How to test

1. 설치/실행

   * `pnpm i`
   * `pnpm dev`

2. 중복 제출 방지 확인

   * PvP 매칭 진입 후 RECORDING 시작
   * **60초 auto-stop** 또는 자동 종료 시나리오 재현
   * Network 탭에서 다음 호출이 **1회만** 발생하는지 확인
     * `POST /pvp/rooms/{roomId}/submissions` (create)
     * (presigned 업로드)
     * `POST /pvp/rooms/submissions/{submissionId}/complete` (complete)
   * React strict mode/effect 재실행 상황에서도 재제출이 발생하지 않는지 확인

3. 소켓 이벤트 토스트 확인
   * `PLAYER_READY`, `ANSWER_SUBMITTED` 이벤트 수신 시
   * 사용자 식별 정보가 아직 준비되지 않은 타이밍에서도 토스트가 정상 노출되는지 확인

4. roomId 타이밍 보정 확인
   * 매칭 페이지 진입 직후 소켓 연결/녹음 API가 올바른 `roomId`를 기준으로 동작하는지 확인
   * 잘못된 roomId로 호출되거나 누락되는 호출이 없는지 확인

---

## 참고 커밋

* `68e1839` fix: remove duplicate submissoins call
