### PR TITLE
fix: add to pvp fail flow

### DIFF
--- a/src/_pages/pvp/create/ui/PvPRoomCreatePage.tsx
+++ b/src/_pages/pvp/create/ui/PvPRoomCreatePage.tsx
@@ -1,19 +1,31 @@
 'use client'
 
+// Next App Router에서 페이지 이동을 제어하는 훅
 import { useRouter } from 'next/navigation'
+// React 훅: 메모이제이션 콜백/가변 ref/local state
 import { useCallback, useRef, useState } from 'react'
 
+// 생성 페이지 이탈(나가기 모달) 관련 훅
 import { usePvPRoomCreateExitGuard } from '@/features/pvp'
+// 상단 모드 헤더 UI
 import { ModeHeader } from '@/shared'
+// 실제 생성 폼/플로우 위젯
 import { PvPMatchingCreate } from '@/widgets/pvp-matching-create'
 
 export function PvPRoomCreatePage() {
+  // create API 진행 중 여부(헤더 뒤로가기 비활성화 용도)
   const [isCreatingRoom, setIsCreatingRoom] = useState(false)
+  // 생성 위젯이 제공하는 "현재 단계용 뒤로가기 핸들러"를 페이지에서 보관
   const createPageBackHandlerRef = useRef<(() => void) | null>(null)
+  // 기본 라우팅 fallback(/pvp) 처리용 router
   const router = useRouter()
+  // 나가기 모달 open/close와 확인/취소 핸들러
   const { isExitAlertOpen, handleExitCancel, handleExitConfirm, setIsExitAlertOpen } =
     usePvPRoomCreateExitGuard()
 
+  // 헤더 뒤로가기 클릭 시 실행:
+  // 1) 생성 위젯이 등록한 단계별 뒤로가기 핸들러가 있으면 그걸 우선 실행
+  // 2) 없으면 /pvp로 이동
   const handleHeaderBack = useCallback(() => {
     if (createPageBackHandlerRef.current) {
       createPageBackHandlerRef.current()
@@ -23,18 +35,23 @@ export function PvPRoomCreatePage() {
     router.replace('/pvp')
   }, [router])
 
+  // 하위 위젯이 넘겨준 뒤로가기 핸들러를 ref에 저장
+  // (함수 참조가 바뀌어도 헤더는 최신 핸들러를 실행할 수 있게 유지)
   const handleCreatePageBackHandlerChange = useCallback((onBackHandler: () => void) => {
     createPageBackHandlerRef.current = onBackHandler
   }, [])
 
   return (
+    // 페이지 루트 레이아웃
     <div className="flex w-full flex-1 flex-col">
+      {/* PvP 생성 헤더: 생성 중에는 뒤로가기 비활성화 */}
       <ModeHeader
         mode="pvp"
         step="matching_create"
         onBack={handleHeaderBack}
         backDisabled={isCreatingRoom}
       />
+      {/* 생성 위젯: 생성 진행 상태/뒤로가기 핸들러/이탈 모달 상태를 페이지와 동기화 */}
       <PvPMatchingCreate
         onCreatingRoomChange={setIsCreatingRoom}
         onBackHandlerChange={handleCreatePageBackHandlerChange}

--- a/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
+++ b/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
@@ -1,14 +1,23 @@
 'use client'
 
+// 라우트 파라미터 조회/페이지 이동 훅
 import { useParams, useRouter } from 'next/navigation'
+// React 훅: 생명주기(effect), 재렌더 없이 값 유지(ref), 로컬 상태(state)
 import { useEffect, useRef, useState } from 'react'
+// 토스트 알림
 import { toast } from 'sonner'
 
+// 카테고리/키워드 표시 UI
 import { PvPCategory, PvPKeyword } from '@/entities/pvp-card'
+// 방 상세 조회 훅
 import { usePvPRoomDetails } from '@/entities/room'
+// 유저 프로필/유저 ID 조회 훅
 import { useMyProfileQuery, useUserId } from '@/entities/user'
+// access token 조회 훅
 import { useAccessToken } from '@/features/auth'
+// 제출/처리 중 로더 UI
 import { FeedbackLoader } from '@/features/levelup-feedback'
+// PvP 매칭 페이지에 필요한 기능/컴포넌트/훅 묶음 import
 import {
   usePvPMatchingExitGuard,
   PvPMatchingWaiting,
@@ -19,92 +28,144 @@ import {
   usePvPRecordController,
   usePvPRoomJoinQuery,
 } from '@/features/pvp'
+// 마이크 UI
 import { MicrophoneBox } from '@/features/record'
+// 공통 UI 컴포넌트
 import { AlertModal, Button, ModeHeader, RecordTipBox, StatusMessage } from '@/shared'
 
+// 공통 메시지 상수
 const ERROR_MESSAGE = '매칭 방에 입장하지 못했습니다.'
 const ROOM_ACCESS_DENIED_MESSAGE = '참여 중인 매칭 방이 아닙니다.'
 const INVALID_ROOM_ID_MESSAGE = '잘못된 방 정보입니다.'
 const LOADING_MESSAGE = '매칭 방 정보를 불러오는 중입니다.'
 const EMPTY_GUEST_NAME = '...'
 
+// 방 상태 상수
 const OPEN_ROOM_STATUS = 'OPEN'
 const THINKING_ROOM_STATUS = 'THINKING'
 const RECORDING_ROOM_STATUS = 'RECORDING'
 const PROCESSING_ROOM_STATUS = 'PROCESSING'
 const FINISHED_ROOM_STATUS = 'FINISHED'
+const CANCELED_ROOM_STATUS = 'CANCELED'
+const EXPIRED_ROOM_STATUS = 'EXPIRED'
 
+// 녹음 시작 실패 토스트 메시지
 const START_RECORDING_ERROR_MESSAGE = '녹음 시작 요청에 실패했습니다. 다시 시도해주세요.'
+// 상대 제출 완료 토스트 메시지
 const OPPONENT_SUBMITTED_TOAST_MESSAGE = '상대방이 음성 제출을 완료했습니다.'
+// 피드백 페이지 라우팅 prefix
 const PVP_FEEDBACK_PATH_PREFIX = '/pvp/feedback'
+const MAIN_PAGE_PATH = '/main'
 
 export function PvPMatchingPage() {
+  // 페이지 라우팅 객체
   const router = useRouter()
+  // 동적 라우트 파라미터(id) 조회
   const params = useParams<{ id: string }>()
+  // URL의 방 id를 숫자로 변환
   const roomId = Number(params.id)
+  // 숫자 변환 실패 여부
   const isInvalidRoomId = Number.isNaN(roomId)
 
+  // 현재 access token
   const accessToken = useAccessToken()
+  // store에 저장된 현재 사용자 id
   const storeUserId = useUserId()
 
+  // store userId가 없으면 myProfile 쿼리로 보완 조회
   const shouldFetchMyProfile = Boolean(accessToken) && storeUserId <= 0
+  // 내 프로필 조회 쿼리
   const myProfileQuery = useMyProfileQuery(accessToken, { enabled: shouldFetchMyProfile })
+  // 최종 사용자 id(store 우선, 없으면 query data)
   const myUserId = storeUserId > 0 ? storeUserId : myProfileQuery.data?.id
+  // 사용자 id 유효 여부
   const hasMyUserId = typeof myUserId === 'number' && myUserId > 0
 
+  // 방 상세 조회(진입 시 기본 정보 확보)
   const roomDetailsQuery = usePvPRoomDetails(accessToken, roomId, {
     enabled: !isInvalidRoomId,
   })
+  // 서버에서 받은 방 상세 데이터
   const roomDetailsFromServer = roomDetailsQuery.data
 
+  // 현재 유저가 host인지
   const isHostUser = hasMyUserId && roomDetailsFromServer?.host.id === myUserId
+  // 현재 유저가 guest인지
   const isGuestUser = hasMyUserId && roomDetailsFromServer?.guest?.id === myUserId
 
+  // 참가자가 아닌 경우에만 join API 시도 여부를 계산한다.
   let shouldAttemptJoinRoom = false
   if (accessToken && hasMyUserId && roomDetailsFromServer && !isHostUser && !isGuestUser) {
     shouldAttemptJoinRoom =
       roomDetailsFromServer.status === OPEN_ROOM_STATUS && roomDetailsFromServer.guest === null
   }
 
+  // guest로 들어오는 경우 join API를 호출한다.
   const roomJoinQuery = usePvPRoomJoinQuery(accessToken, roomId, {
     enabled: shouldAttemptJoinRoom,
   })
+  // join 성공 시 방 상세는 join 응답을 우선 사용
   const joinedRoomDetails = roomJoinQuery.data?.ok ? roomJoinQuery.data.data : null
+  // join 결과가 없으면 기존 room details를 fallback으로 사용
   const resolvedRoomDetails = joinedRoomDetails ?? roomDetailsFromServer ?? null
+  // 실제 사용할 room id
   const joinedRoomId = resolvedRoomDetails?.room.id ?? null
+  // 소켓/녹음 컨트롤러에서 사용할 room id
   const socketRoomId = joinedRoomId
 
+  // 현재 유저가 이 방의 실제 참가자인지 계산
   let isParticipantUser = false
   if (hasMyUserId && resolvedRoomDetails) {
     isParticipantUser =
       resolvedRoomDetails.host.id === myUserId || resolvedRoomDetails.guest?.id === myUserId
   }
+  // 참가자가 맞을 때만 participant room id를 노출한다.
   const participantRoomId = isParticipantUser ? joinedRoomId : null
 
+  // 프로필 조회 로딩 여부
   const isProfileLoading = shouldFetchMyProfile && myProfileQuery.isLoading
+  // 방 조회 로딩 여부
   const isRoomLoading = roomDetailsQuery.isLoading
+  // join API 로딩 여부
   const isJoinLoading = shouldAttemptJoinRoom && roomJoinQuery.isLoading
 
+  // 준비(start-recording 요청) 진행 중 상태
   const [isStartingRecordingRequest, setIsStartingRecordingRequest] = useState(false)
+  // 내가 준비 버튼을 이미 눌렀는지 여부
   const [isReadySubmitted, setIsReadySubmitted] = useState(false)
+  // FINISHED 라우팅 중복 방지 ref
   const hasRoutedToFeedbackRef = useRef(false)
+  // 취소/만료 라우팅 중복 방지 ref
+  const hasRoutedToMainRef = useRef(false)
 
+  // 매칭 소켓 구독 훅
   const {
+    // 실시간 room status
     liveRoomStatus,
+    // THINKING에서 내려오는 키워드명
     thinkingKeywordName,
+    // THINKING 종료 시각(ms)
     thinkingEndsAtMs,
+    // 상태를 수동으로 덮어쓰기 위한 setter
     setLiveRoomStatus,
+    // 소켓 연결/구독 정리 함수
     cleanupMatchingConnection,
   } = usePvPMatchingSocket({
+    // 토큰이 있어야 소켓 연결 가능
     accessToken,
+    // 구독할 room id
     joinedRoomId: socketRoomId,
+    // 메시지 발신자 판별용 현재 유저 id
     myUserId,
+    // 내가 준비했을 때 local 상태 반영
     onSelfReady: () => {
       setIsReadySubmitted(true)
     },
+    // 내가 제출 완료한 이벤트 수신 시 로더 상태 유지
     onSelfAnswerSubmitted: () => {
       markSubmissionCompleted()
     },
+    // 상대 제출 완료 이벤트 수신 시(내가 아직 녹음중이면) 토스트 표시
     onOpponentAnswerSubmitted: () => {
       if (isRecording && !isSubmissionCompleted) {
         toast.info(OPPONENT_SUBMITTED_TOAST_MESSAGE)
@@ -112,25 +173,44 @@ export function PvPMatchingPage() {
     },
   })
 
+  // 페이지 이탈(뒤로가기/종료) 가드 훅
   const { isExitAlertOpen, handleBack, handleExitConfirm, handleExitCancel, setIsExitAlertOpen } =
     usePvPMatchingExitGuard({
+      // 방 나가기 API용 토큰
       accessToken,
+      // 참가자인 경우에만 exit API를 수행하도록 participant room id를 전달
       joinedRoomId: participantRoomId,
+      // 이탈 시 소켓 정리
       cleanupMatchingConnection,
     })
 
+  // 실시간 status가 있으면 우선 사용, 없으면 초기 방 상태 사용
   const latestRoomStatus = liveRoomStatus ?? resolvedRoomDetails?.status ?? null
+  // FINISHED 여부
   const isFinishedStatus = latestRoomStatus === FINISHED_ROOM_STATUS
+  // 취소/만료 여부
+  const shouldRouteToMain =
+    latestRoomStatus === CANCELED_ROOM_STATUS || latestRoomStatus === EXPIRED_ROOM_STATUS
 
+  // 녹음 시작/종료/제출을 담당하는 컨트롤러
   const {
+    // 현재 녹음 중 여부
     isRecording,
+    // 일시정지 여부(현재 PvP는 pause 비활성 설계지만 UI 호환으로 유지)
     isPaused,
+    // 녹음 경과 초
     elapsedSeconds,
+    // 녹음 완료 blob
     recordedBlob,
+    // 마이크 상호작용 허용 여부
     isMicInteractionAllowed,
+    // 제출 API 처리 중 여부
     isSubmittingSubmission,
+    // 제출 완료 상태(로더 유지용)
     isSubmissionCompleted,
+    // self ANSWER_SUBMITTED 수신 시 완료 상태 동기화 함수
     markSubmissionCompleted,
+    // 마이크 클릭 핸들러
     handlePvPMicClick,
   } = usePvPRecordController({
     accessToken,
@@ -138,93 +218,158 @@ export function PvPMatchingPage() {
     roomStatus: latestRoomStatus,
   })
 
+  // FINISHED 수신 시 피드백 페이지로 1회만 이동
   useEffect(() => {
-    if (!isFinishedStatus) return
-    if (hasRoutedToFeedbackRef.current) return
+    // 취소/만료 상태가 아니면 아무것도 하지 않음
+    if (!shouldRouteToMain) return
+    // 이미 이동 중이면 중복 실행 방지
+    if (hasRoutedToMainRef.current) return
 
+    hasRoutedToMainRef.current = true
+
+    // 소켓 정리 후 메인으로 이동
+    const moveToMainPage = async () => {
+      await cleanupMatchingConnection()
+      router.replace(MAIN_PAGE_PATH)
+    }
+
+    void moveToMainPage()
+  }, [cleanupMatchingConnection, router, shouldRouteToMain])
+
+  useEffect(() => {
+    // FINISHED가 아니면 아무것도 하지 않음
+    if (!isFinishedStatus) return
+    // 이미 라우팅 중/완료면 중복 실행 방지
+    if (hasRoutedToFeedbackRef.current) return
+    // 취소/만료 라우팅이 우선이다.
+    if (shouldRouteToMain) return
+
+    // 참가자 room id가 있으면 우선 사용, 없으면 URL room id fallback
     const targetRoomId = participantRoomId ?? roomId
+    // id가 비정상이면 중단
     if (!targetRoomId || Number.isNaN(targetRoomId)) return
 
+    // 중복 이동 방지 플래그 on
     hasRoutedToFeedbackRef.current = true
 
+    // 소켓 정리 후 피드백 페이지로 교체 이동
     const moveToFeedbackPage = async () => {
       await cleanupMatchingConnection()
       router.replace(`${PVP_FEEDBACK_PATH_PREFIX}/${targetRoomId}`)
     }
 
+    // 비동기 실행
     void moveToFeedbackPage()
-  }, [cleanupMatchingConnection, isFinishedStatus, participantRoomId, roomId, router])
+  }, [
+    cleanupMatchingConnection,
+    isFinishedStatus,
+    participantRoomId,
+    roomId,
+    router,
+    shouldRouteToMain,
+  ])
 
+  // URL id가 잘못되면 즉시 에러 메시지 렌더
   if (isInvalidRoomId) {
     return <StatusMessage message={INVALID_ROOM_ID_MESSAGE} />
   }
 
+  // 필수 데이터 로딩 중이면 로딩 메시지 렌더
   if (isProfileLoading || isRoomLoading || isJoinLoading) {
     return <StatusMessage message={LOADING_MESSAGE} />
   }
 
+  // 방 조회 자체가 실패했거나 방 데이터가 없으면 진입 실패 처리
   if (roomDetailsQuery.isError || !roomDetailsFromServer) {
     return <StatusMessage message={ERROR_MESSAGE} />
   }
 
+  // join이 필요한 케이스에서 join 실패 시 진입 실패 처리
   if (shouldAttemptJoinRoom && (roomJoinQuery.isError || roomJoinQuery.data?.ok === false)) {
     return <StatusMessage message={ERROR_MESSAGE} />
   }
 
+  // 최종 방 데이터가 없거나 참가자가 아니면 접근 거부 처리
   if (!resolvedRoomDetails || !isParticipantUser) {
     return <StatusMessage message={ROOM_ACCESS_DENIED_MESSAGE} />
   }
 
+  // UI 렌더 기준 room status (실시간 우선)
   const roomStatusForDisplay = liveRoomStatus ?? resolvedRoomDetails.status
+  // RECORDING 단계 여부 (헤더 step/마이크 UI 분기에 사용)
   const isRecordingStep = roomStatusForDisplay === RECORDING_ROOM_STATUS
+  // PROCESSING 단계 여부
   const isProcessingStep = roomStatusForDisplay === PROCESSING_ROOM_STATUS
+  // OPEN + HOST 상태면 대기 화면(PvPMatchingWaiting) 렌더
   const isHostWaitingOpenState =
     roomStatusForDisplay === OPEN_ROOM_STATUS && resolvedRoomDetails.host.id === myUserId
+  // 대기 화면이 아닐 때만 전투 UI(키워드/녹음/준비 버튼)를 렌더
   const shouldRenderBattleUi = !isHostWaitingOpenState
+  // 녹음/처리/완료 단계에서는 헤더 뒤로가기 비활성화
   const isHeaderBackDisabled =
     roomStatusForDisplay === RECORDING_ROOM_STATUS ||
     roomStatusForDisplay === PROCESSING_ROOM_STATUS ||
     roomStatusForDisplay === FINISHED_ROOM_STATUS
 
+  // THINKING에서 소켓 키워드가 오면 우선, 없으면 초기 keyword 사용
   const keywordNameForDisplay = thinkingKeywordName ?? resolvedRoomDetails.keyword?.name ?? ''
+  // THINKING 단계 여부(카운트다운/준비 버튼 분기에 사용)
   const isThinkingStep = roomStatusForDisplay === THINKING_ROOM_STATUS
+  // 제출/처리/완료 상태에서는 로더를 표시
   const shouldShowFeedbackLoader =
     isSubmittingSubmission || isSubmissionCompleted || isProcessingStep || isFinishedStatus
 
+  // 준비 버튼 활성 조건
   const canStartPvPRecording =
+    // THINKING 단계여야 준비 버튼 동작
     isThinkingStep &&
+    // 인증 토큰 필요
     Boolean(accessToken) &&
+    // 방 id 필요
     Boolean(socketRoomId) &&
+    // start-recording 요청 중이 아니어야 함
     !isStartingRecordingRequest &&
+    // 이미 준비를 누르지 않았어야 함
     !isReadySubmitted
 
+  // 준비 버튼 클릭 핸들러
   const handleReadyButtonClick = async () => {
+    // 필수값 없거나 요청 중복이면 중단
     if (!accessToken || !socketRoomId) return
     if (isReadySubmitted || isStartingRecordingRequest) return
 
+    // 중복 클릭 방지 상태 on
     setIsReadySubmitted(true)
     setIsStartingRecordingRequest(true)
+    // 서버에 RECORDING 시작 요청
     const startRecordingResult = await startPvPRecording(accessToken, socketRoomId)
+    // 요청 종료
     setIsStartingRecordingRequest(false)
 
+    // 실패 시 준비 상태 롤백 + 토스트
     if (!startRecordingResult.ok) {
       setIsReadySubmitted(false)
       toast.error(START_RECORDING_ERROR_MESSAGE)
       return
     }
 
+    // 성공 시 응답 status를 즉시 UI 상태에 반영
     setLiveRoomStatus(startRecordingResult.data.status)
   }
 
   return (
+    // 페이지 전체 세로 레이아웃
     <div className="flex h-full w-full flex-col gap-4">
+      {/* 상단 모드 헤더 */}
       <ModeHeader
         mode="pvp"
         step={isRecordingStep ? 'recording' : 'battle'}
         onBack={handleBack}
         backDisabled={isHeaderBackDisabled}
       />
+      {/* 카테고리 정보 */}
       <PvPCategory categoryName={resolvedRoomDetails.category.name} />
+      {/* host가 OPEN 상태로 대기 중이면 waiting UI, 아니면 참가자 UI */}
       {isHostWaitingOpenState ? (
         <PvPMatchingWaiting
           leftProfile={{
@@ -248,17 +393,22 @@ export function PvPMatchingPage() {
           }}
         />
       )}
+      {/* host OPEN 대기 상태가 아닐 때만 전투 UI 렌더 */}
       {shouldRenderBattleUi ? (
         <>
+          {/* 현재 대결 키워드 */}
           <PvPKeyword keywordName={keywordNameForDisplay} />
+          {/* THINKING 단계 카운트다운 */}
           <PvPThinkingCountdown
             isThinkingStep={isThinkingStep}
             thinkingEndsAtMs={thinkingEndsAtMs}
           />
+          {/* 제출/처리/완료 상태면 로더, 아니면 마이크 박스 */}
           {shouldShowFeedbackLoader ? (
             <FeedbackLoader status={isProcessingStep ? 'PROCESSING' : 'PENDING'} />
           ) : (
             <MicrophoneBox
+              // 마이크 클릭은 컨트롤러 핸들러로 위임
               onMicClick={() => {
                 void handlePvPMicClick()
               }}
@@ -271,7 +421,9 @@ export function PvPMatchingPage() {
               elapsedSeconds={elapsedSeconds}
             />
           )}
+          {/* 녹음 가이드 박스 */}
           <RecordTipBox />
+          {/* 준비 버튼 영역 */}
           <div className="mb-6 flex w-full items-center justify-center">
             <Button
               variant="record_confirm_btn"
@@ -285,6 +437,7 @@ export function PvPMatchingPage() {
           </div>
         </>
       ) : null}
+      {/* 매칭 종료 확인 모달 */}
       <AlertModal
         open={isExitAlertOpen}
         onOpenChange={setIsExitAlertOpen}

--- a/src/features/pvp/model/usePvPMatchingCreateFlow.ts
+++ b/src/features/pvp/model/usePvPMatchingCreateFlow.ts
@@ -1,40 +1,64 @@
 'use client'
 
+// 페이지 라우팅(생성 성공 후 매칭 페이지 이동, 뒤로가기 fallback 이동)
 import { useRouter } from 'next/navigation'
+// React 훅(핸들러 메모이제이션/부모 동기화 effect/local state)
 import { useCallback, useEffect, useState } from 'react'
+// 토스트 알림
 import { toast } from 'sonner'
 
+// 방 생성 API
 import { createPvPRoom } from '@/entities/room'
+// access token 읽기
 import { useAccessToken } from '@/features/auth'
 
 import type { CategoryItemType } from '@/entities/category'
 
+// 생성 실패 시 사용자에게 보여줄 메시지
 const CREATE_ROOM_ERROR_MESSAGE = '방을 만들던 중 오류가 발생하였습니다.'
+// 생성 성공 후 이동할 경로 prefix
 const MATCHING_PATH_PREFIX = '/pvp/matching'
 
+// 방 이름 앞/뒤 공백 제거 유틸(중간 공백은 유지)
 const normalizeRoomNameBoundarySpaces = (value: string) => value.trim()
 
 type UsePvPMatchingCreateFlowParams = {
+  // 부모 페이지에 생성 진행 상태 전달(헤더 back 비활성화)
   onCreatingRoomChange?: (isCreatingRoom: boolean) => void
+  // 부모 페이지 헤더가 실행할 뒤로가기 핸들러 등록
   onBackHandlerChange?: (onBackHandler: () => void) => void
+  // 이탈(나가기) 성공 시 부모 후처리 콜백
   onExitConfirm?: () => void
 }
 
 type UsePvPMatchingCreateFlowResult = {
+  // 현재 선택된 카테고리
   selectedCategory: CategoryItemType | null
   // 카테고리 단계 -> 방 이름 단계 전환 여부
   isNextClicked: boolean | null
+  // 카테고리 단계인지 여부(파생 상태)
   isCategoryStep: boolean
+  // 방 이름 입력값
   roomName: string
+  // create API 진행 중 여부
   isCreatingRoom: boolean
+  // 버튼 비활성 여부(입력 미완료 or 생성 중)
   isCreateButtonDisabled: boolean
+  // 버튼 variant(category/create)
   createButtonVariant: 'category' | 'create'
+  // 카테고리 선택/해제
   handleCategorySelect: (category: CategoryItemType) => void
+  // 방 이름 입력 변경
   handleRoomNameChange: (value: string) => void
+  // 방 이름 blur 시 정규화
   handleRoomNameBlur: () => void
+  // 헤더 뒤로가기 클릭 시 호출할 핸들러
   handleBackClick: () => void
+  // 다음/방 만들기 버튼 클릭 핸들러
   handleCreateButtonClick: () => Promise<void>
+  // 이탈 확인 기본 핸들러(현재는 true 반환)
   handleExitConfirm: () => Promise<boolean>
+  // AlertModal 나가기 액션 핸들러
   handleAlertExitConfirm: () => Promise<void>
 }
 
@@ -43,41 +67,46 @@ export function usePvPMatchingCreateFlow({
   onBackHandlerChange,
   onExitConfirm,
 }: UsePvPMatchingCreateFlowParams = {}): UsePvPMatchingCreateFlowResult {
-  // 사용자가 선택한 카테고리(1단계)
+  // 1단계(카테고리)의 선택 상태
   const [selectedCategory, setSelectedCategory] = useState<CategoryItemType | null>(null)
-  // 1단계(카테고리)에서 2단계(방 이름 입력)로 넘어갔는지 표시
+  // 단계 전환 상태(null/false: 1단계, true: 2단계)
   const [isNextClicked, setIsNextClicked] = useState<boolean | null>(null)
-  // 방 이름 입력값(2단계)
+  // 2단계(방 이름)의 입력 상태
   const [roomName, setRoomName] = useState('')
-  // createPvPRoom 요청 진행 상태 (중복 클릭 방지 + UI 비활성화 용도)
+  // 생성 요청 진행 중 상태(중복 호출 방지 + UI 잠금)
   const [isCreatingRoom, setIsCreatingRoom] = useState(false)
 
+  // 라우팅 제어 객체
   const router = useRouter()
+  // 생성 API 인증 토큰
   const accessToken = useAccessToken()
 
-  // 1단계 유효성: 카테고리가 선택되었는지
+  // 1단계 필수값 충족 여부
   const hasSelectedCategory = Boolean(selectedCategory)
-  // 아직 "다음"을 누르지 않았으면 카테고리 단계
+  // 현재 카테고리 단계인지 판단
   const isCategoryStep = !isNextClicked
 
-  // 버튼 라벨/의미는 현재 단계에 맞춰 category -> create 로만 사용
+  // CTA 버튼 variant는 단계에 따라 `category` 또는 `create`
   const createButtonVariant = isCategoryStep ? 'category' : 'create'
 
-  // 단계별 필수 입력값 검증:
+  // 단계별 유효성 검증:
   // - 1단계: 카테고리 필수
   // - 2단계: trim 기준 방 이름 필수
   const isFormInvalid = isCategoryStep ? !hasSelectedCategory : roomName.trim().length === 0
-  // 최종 버튼 비활성 조건 (입력 미완료 또는 생성 요청 진행 중)
+  // 버튼 비활성 최종 조건
   const isCreateButtonDisabled = isFormInvalid || isCreatingRoom
 
+  // 카테고리 선택 핸들러: 같은 항목 재클릭 시 해제
   const handleCategorySelect = useCallback((category: CategoryItemType) => {
     setSelectedCategory((prev) => (prev?.id === category.id ? null : category))
   }, [])
 
+  // 방 이름 입력 변경 핸들러
   const handleRoomNameChange = useCallback((value: string) => {
     setRoomName(value)
   }, [])
 
+  // 포커스 아웃 시 방 이름 정규화(앞/뒤 공백 제거)
   const handleRoomNameBlur = useCallback(() => {
     setRoomName((prev) => normalizeRoomNameBoundarySpaces(prev))
   }, [])
@@ -86,14 +115,18 @@ export function usePvPMatchingCreateFlow({
   // 1) 카테고리 미선택 -> /pvp 이동
   // 2) 카테고리 선택 + 방 이름 미입력 -> 카테고리 선택 해제
   // 3) 카테고리 선택 + 방 이름 입력 -> 방 이름 + 카테고리 선택 모두 초기화
+  // 헤더 뒤로가기 핸들러
   const handleBackClick = useCallback(() => {
+    // 생성 중에는 뒤로가기 동작을 막는다.
     if (isCreatingRoom) return
 
+    // 아직 카테고리를 선택하지 않았으면 목록(/pvp)으로 이동
     if (!selectedCategory) {
       router.replace('/pvp')
       return
     }
 
+    // 카테고리는 선택했지만 방 이름이 비어 있으면 단계 초기화 후 목록으로 이동
     if (roomName.trim().length === 0) {
       setSelectedCategory(null)
       setIsNextClicked(null)
@@ -101,39 +134,41 @@ export function usePvPMatchingCreateFlow({
       return
     }
 
+    // 카테고리/방 이름을 모두 초기화해 1단계로 복귀
     setRoomName('')
     setSelectedCategory(null)
     setIsNextClicked(null)
   }, [isCreatingRoom, roomName, router, selectedCategory])
 
-  // 부모 페이지와 생성 진행 상태를 동기화한다.
+  // 생성 진행 상태를 부모 페이지와 동기화(헤더 back 비활성화에 사용)
   useEffect(() => {
     onCreatingRoomChange?.(isCreatingRoom)
   }, [isCreatingRoom, onCreatingRoomChange])
 
-  // 부모 페이지 헤더가 사용할 뒤로가기 핸들러를 등록한다.
+  // 부모 페이지 헤더가 실행할 뒤로가기 핸들러를 등록
   useEffect(() => {
     onBackHandlerChange?.(handleBackClick)
   }, [handleBackClick, onBackHandlerChange])
 
-  // "다음/방 만들기" 클릭 핸들러
+  // 다음/방 만들기 버튼 클릭 핸들러
   const handleCreateButtonClick = async () => {
-    // 1단계에서는 API 호출 없이 2단계 UI로만 전환
+    // 1단계에서는 API 호출 없이 2단계로 전환만 수행
     if (!isNextClicked) {
       setIsNextClicked(true)
       return
     }
 
-    // 2단계에서 필수 선행값이 없으면 요청하지 않는다.
+    // 토큰/카테고리 없으면 생성 요청하지 않음
     if (!accessToken || !selectedCategory) return
 
-    // 서버에 보낼 값은 앞/뒤 공백을 제거한 방 이름으로 정규화
+    // 서버 전송 전 방 이름 정규화
     const normalizedRoomName = normalizeRoomNameBoundarySpaces(roomName)
     if (normalizedRoomName.length === 0) return
 
+    // 생성 요청 중복 방지
     if (isCreatingRoom) return
 
-    // 요청 시작 시 즉시 비활성화
+    // 요청 시작(버튼/뒤로가기 비활성화)
     setIsCreatingRoom(true)
 
     // 방 생성 API 호출
@@ -142,21 +177,24 @@ export function usePvPMatchingCreateFlow({
       roomName: normalizedRoomName,
     })
 
-    // 생성 실패 시 라우팅하지 않고 사용자에게 오류를 알린다.
+    // 생성 실패: 토스트 표시 후 생성 중 상태 해제
     if (!createdRoom) {
       toast.error(CREATE_ROOM_ERROR_MESSAGE)
       setIsCreatingRoom(false)
       return
     }
 
-    // 2안: 생성 직후 대기 페이지를 거치지 않고 매칭 페이지로 즉시 이동
+    // 생성 성공: 대기 페이지를 거치지 않고 매칭 페이지로 즉시 이동
     router.replace(`${MATCHING_PATH_PREFIX}/${createdRoom.room.id}`)
   }
 
+  // 나가기 확인 기본 처리(현재는 항상 성공 처리)
   const handleExitConfirm = useCallback(async () => {
     return true
   }, [])
 
+  // AlertModal의 "나가기" 액션 처리:
+  // 훅 내부 확인 -> 성공 시 부모 후처리 콜백 실행
   const handleAlertExitConfirm = useCallback(async () => {
     const isExitSuccess = await handleExitConfirm()
     if (!isExitSuccess) return
@@ -164,6 +202,7 @@ export function usePvPMatchingCreateFlow({
   }, [handleExitConfirm, onExitConfirm])
 
   return {
+    // 상태
     selectedCategory,
     isNextClicked,
     isCategoryStep,
@@ -171,6 +210,7 @@ export function usePvPMatchingCreateFlow({
     isCreatingRoom,
     isCreateButtonDisabled,
     createButtonVariant,
+    // 핸들러
     handleCategorySelect,
     handleRoomNameChange,
     handleRoomNameBlur,

--- a/src/widgets/pvp-matching-create/ui/PvPMatchingCreate.tsx
+++ b/src/widgets/pvp-matching-create/ui/PvPMatchingCreate.tsx
@@ -1,20 +1,29 @@
 'use client'
 
+// 토큰을 읽어 카테고리 API 요청 등에 전달
 import { useAccessToken } from '@/features/auth'
+// 생성 화면을 구성하는 UI/플로우 훅
 import {
   RoomCategorySelect,
   RoomCreateButton,
   RoomNameSetting,
   usePvPMatchingCreateFlow,
 } from '@/features/pvp'
+// 생성 취소 확인 모달
 import { AlertModal } from '@/shared'
 
 type PvPMatchingCreateProps = {
+  // 부모 페이지에 "방 생성 진행 중" 상태를 알림(헤더 뒤로가기 비활성화)
   onCreatingRoomChange?: (isCreatingRoom: boolean) => void
+  // 부모 페이지 헤더가 사용할 뒤로가기 핸들러를 등록
   onBackHandlerChange?: (onBackHandler: () => void) => void
+  // 외부에서 제어하는 나가기 모달 open 상태
   isExitAlertOpen?: boolean
+  // 외부에서 제어하는 나가기 모달 open 변경 핸들러
   onExitAlertOpenChange?: (open: boolean) => void
+  // 모달의 "나가기"가 최종 성공했을 때 부모 후처리
   onExitConfirm?: () => void
+  // 모달의 "계속하기/닫기" 핸들러
   onExitCancel?: () => void
 }
 
@@ -26,28 +35,47 @@ export function PvPMatchingCreate({
   onExitConfirm,
   onExitCancel,
 }: PvPMatchingCreateProps) {
+  // 카테고리 조회 컴포넌트에 전달할 access token
   const accessToken = useAccessToken()
 
-  // 매칭 생성 플로우 상태/핸들러(카테고리 선택 -> 방 이름 입력 -> 생성 후 매칭 페이지 이동)
+  // 생성 플로우의 상태/액션을 훅에서 가져온다.
+  // (카테고리 단계 -> 방 이름 단계 -> create API -> matching 페이지 이동)
   const {
+    // 현재 선택된 카테고리(없으면 null)
     selectedCategory,
+    // true면 카테고리 단계, false면 방 이름 단계
     isCategoryStep,
+    // 방 이름 입력값
     roomName,
+    // 입력값/요청 상태를 반영한 버튼 비활성 여부
     isCreateButtonDisabled,
+    // 버튼 variant(category/create)
     createButtonVariant,
+    // 카테고리 선택 토글
     handleCategorySelect,
+    // 방 이름 입력 변경
     handleRoomNameChange,
+    // 방 이름 blur 시 앞뒤 공백 정규화
     handleRoomNameBlur,
+    // 다음/방 만들기 버튼 클릭
     handleCreateButtonClick,
+    // 모달의 나가기 클릭 처리(훅 내부에서 성공 여부 처리 후 부모 콜백 호출)
     handleAlertExitConfirm,
   } = usePvPMatchingCreateFlow({
+    // 생성 진행 상태를 부모로 올린다.
     onCreatingRoomChange,
+    // 헤더 뒤로가기 핸들러를 부모에 등록한다.
     onBackHandlerChange,
+    // 이탈 성공 후 부모 후처리를 수행한다.
     onExitConfirm,
   })
 
   return (
+    // 생성 위젯 루트 레이아웃
     <div className="flex w-full flex-1 flex-col">
+      {/* 단계별 렌더링:
+          - 카테고리 단계: 카테고리 선택 UI
+          - 방 이름 단계: 방 이름 입력 UI */}
       {isCategoryStep ? (
         <RoomCategorySelect
           accessToken={accessToken}
@@ -62,11 +90,13 @@ export function PvPMatchingCreate({
           onRoomNameBlur={handleRoomNameBlur}
         />
       )}
+      {/* 하단 CTA 버튼(다음/방 만들기) */}
       <RoomCreateButton
         variant={createButtonVariant}
         disabled={isCreateButtonDisabled}
         onClick={handleCreateButtonClick}
       />
+      {/* 생성 취소(나가기) 확인 모달 */}
       <AlertModal
         open={isExitAlertOpen}
         onOpenChange={onExitAlertOpenChange}


### PR DESCRIPTION
## 개요
* PvP 매칭/방 생성 플로우에서 **라우팅 및 뒤로가기 동작을 안정화**
* 매칭 페이지에서 방 상태가 실패 상태(`CANCELED`, `EXPIRED`)로 전환되면 **소켓 정리 후 `/main`으로 즉시 라우팅**되도록 처리했고, `FINISHED`(피드백 이동)보다 실패 분기가 먼저 적용되도록 우선순위를 정리
* 방 생성 페이지는 위젯이 제공하는 뒤로가기 핸들러를 **페이지 헤더와 연결**하고, 생성 중에는 헤더 뒤로가기를 비활성화하도록 개선

---

## 변경사항

### 1) 매칭 페이지 실패 상태 라우팅 추가
* 파일: `src/_pages/pvp/matching/ui/PvPMatchingPage.tsx`
* 내용:
  * 방 상태가 `CANCELED` 또는 `EXPIRED`일 때:
    * 소켓 정리 후 `/main`으로 `replace` 이동
  * `FINISHED`로 피드백 페이지 이동 흐름보다 **`CANCELED/EXPIRED` 분기가 먼저 타도록** 분기 순서 정리
  * 매칭 페이지 전반 설명 주석 추가

### 2) PvP 방 생성 페이지 뒤로가기 흐름 정리
* 파일: `src/_pages/pvp/create/ui/PvPRoomCreatePage.tsx`
* 내용:
  * 생성 위젯이 등록한 뒤로가기 핸들러를 **페이지 헤더 뒤로가기와 연결**
  * 핸들러가 없으면 `/pvp`로 fallback 이동
  * 방 생성 중에는 **헤더 뒤로가기 비활성화**

### 3) PvP 방 생성 위젯 역할/동기화 정리
* 파일: `src/widgets/pvp-matching-create/ui/PvPMatchingCreate.tsx`
* 내용:
  * `onCreatingRoomChange`, `onBackHandlerChange`로 부모 페이지와
    * 생성 상태
    * 뒤로가기 핸들러
      를 동기화
  * 생성 화면/나가기 모달 역할을 주석으로 명확화

### 4) 방 생성 플로우 훅 정리
* 파일: `src/features/pvp/model/usePvPMatchingCreateFlow.ts`
* 내용:
  * 생성 중 상태를 부모로 올려 헤더 뒤로가기와 연동
  * 뒤로가기 규칙 정리:
    * 카테고리 미선택: `/pvp` 이동
    * 카테고리 선택 + 방 이름 비어 있음: 카테고리 해제
    * 카테고리 선택 + 방 이름 입력됨: 방 이름 + 카테고리 모두 초기화
  * 방 생성 성공 시 `/pvp/matching/{roomId}`로 `replace` 이동
  * 설명 주석 추가

---

## Screenshots (UI 변경 시)

---

## How to test

1. 실행

* `pnpm i`
* `pnpm dev`

2. 매칭 실패 라우팅 확인

* `/pvp/matching/{roomId}` 진입
* 소켓 이벤트/서버 응답으로 room status가 `CANCELED` 또는 `EXPIRED`로 전환되는 상황 재현
* 다음을 확인:

  * 소켓 정리가 먼저 수행되는지
  * 이후 `/main`으로 `replace` 이동되는지
  * `FINISHED`로 피드백 라우팅보다 실패 분기가 우선 적용되는지

3. 방 생성 페이지 뒤로가기 확인

* `/pvp/create` 진입
* 케이스별 헤더 뒤로가기 동작 확인:

  * 위젯 핸들러가 등록된 상태면 해당 핸들러 실행
  * 핸들러 미등록이면 `/pvp`로 fallback
* 방 생성 요청 중(creating 상태)에는 헤더 뒤로가기가 비활성화되는지 확인

4. 생성 플로우 뒤로가기 규칙 확인(위젯 핸들러 경로)

* 카테고리 미선택: 뒤로 → `/pvp`
* 카테고리 선택 + 방 이름 없음: 뒤로 → 카테고리 해제
* 카테고리 선택 + 방 이름 있음: 뒤로 → 방 이름/카테고리 초기화
* 생성 성공 시 `/pvp/matching/{roomId}`로 `replace` 이동 확인

---

## 참고 커밋
* `e45e12b` fix: add to pvp fail flow
