### PR TITLE
refactor: pvp matching page flow

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
+import './.next/dev/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,7 @@ const customDistDir = process.env.NEXT_DIST_DIR
 const isAnalyze = process.env.ANALYZE === 'true'
 
 /**
- * ANALYZE=true 일 때만 @next/bundle-analyzer를 동적으로 로드합니다.
+ * ANALYZE=true 일 때만 @next/bundle-analyzer를 동적으로 로드
  * (CI 서버에 패키지가 없어도 ANALYZE=false면 빌드가 안 터짐)
  */
 const withBundleAnalyzer = isAnalyze

--- a/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
+++ b/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
@@ -7,28 +7,23 @@ import { toast } from 'sonner'
 import { PvPCategory } from '@/entities/pvp-card'
 import { useAccessToken } from '@/features/auth'
 import {
-  FINISHED_ROOM_STATUS,
-  OPEN_ROOM_STATUS,
-  PROCESSING_ROOM_STATUS,
+  getPvPMatchingUiState,
   PVP_MATCHING_ACCESS_DENIED_MESSAGE,
-  PVP_MATCHING_EMPTY_GUEST_NAME,
   PVP_MATCHING_ERROR_MESSAGE,
   PVP_MATCHING_INVALID_ROOM_ID_MESSAGE,
   PVP_MATCHING_LOADING_MESSAGE,
   PVP_MATCHING_PENDING_KEYWORD_MESSAGE,
   PVP_OPPONENT_SUBMITTED_TOAST_MESSAGE,
-  PVP_START_RECORDING_ERROR_MESSAGE,
   PvPBattleSection,
   PvPMatchingWaiting,
   PvPParticipants,
-  RECORDING_ROOM_STATUS,
-  startPvPRecording,
-  THINKING_ROOM_STATUS,
   usePvPMatchingAccess,
   usePvPMatchingExitGuard,
   usePvPMatchingRouting,
+  usePvPReadyAction,
   usePvPMatchingSocket,
   usePvPRecordController,
+  toPvPParticipantProfiles,
 } from '@/features/pvp'
 import { AlertModal, ModeHeader, StatusMessage } from '@/shared'
 
@@ -36,6 +31,23 @@ export function PvPMatchingPage() {
   const params = useParams<{ id: string }>()
   const roomId = Number(params.id)
   const accessToken = useAccessToken()
+
+  // 내가 준비 버튼을 이미 눌렀는지 여부
+  const [isReadySubmitted, setIsReadySubmitted] = useState(false)
+
+  function handleSelfReadyMessage() {
+    setIsReadySubmitted(true)
+  }
+
+  function handleSelfAnswerSubmittedMessage() {
+    markSubmissionCompleted()
+  }
+
+  function handleOpponentAnswerSubmittedMessage() {
+    if (isRecording && !isSubmissionCompleted) {
+      toast.info(PVP_OPPONENT_SUBMITTED_TOAST_MESSAGE)
+    }
+  }
 
   // 접근 검증/room join/participant 판별은 전용 훅으로 분리
   const {
@@ -50,11 +62,6 @@ export function PvPMatchingPage() {
     roomId,
   })
 
-  // 준비(start-recording 요청) 진행 중 상태
-  const [isStartingRecordingRequest, setIsStartingRecordingRequest] = useState(false)
-  // 내가 준비 버튼을 이미 눌렀는지 여부
-  const [isReadySubmitted, setIsReadySubmitted] = useState(false)
-
   // 매칭 소켓 구독 훅
   const {
     liveRoomStatus,
@@ -68,19 +75,24 @@ export function PvPMatchingPage() {
     // 메시지 발신자 판별용 현재 유저 id
     myUserId,
     // 내가 준비했을 때 local 상태 반영
-    onSelfReady: () => {
-      setIsReadySubmitted(true)
-    },
+    onSelfReady: handleSelfReadyMessage,
     // 내가 제출 완료한 이벤트 수신 시 로더 상태 유지
-    onSelfAnswerSubmitted: () => {
-      markSubmissionCompleted()
-    },
+    onSelfAnswerSubmitted: handleSelfAnswerSubmittedMessage,
     // 상대 제출 완료 이벤트 수신 시(내가 아직 녹음중이면) 토스트 표시
-    onOpponentAnswerSubmitted: () => {
-      if (isRecording && !isSubmissionCompleted) {
-        toast.info(PVP_OPPONENT_SUBMITTED_TOAST_MESSAGE)
-      }
-    },
+    onOpponentAnswerSubmitted: handleOpponentAnswerSubmittedMessage,
+  })
+
+  // 소켓 상태가 있으면 우선 사용하고, 없으면 서버 초기 상태를 현재 상태로 사용한다.
+  const currentRoomStatus = liveRoomStatus ?? resolvedRoomDetails?.status ?? null
+
+  // 준비 버튼 클릭 액션
+  const { canStartPvPRecording, handleReadyButtonClick } = usePvPReadyAction({
+    accessToken,
+    roomId: joinedRoomId,
+    roomStatus: currentRoomStatus,
+    isReadySubmitted,
+    setIsReadySubmitted,
+    onReadySuccess: setLiveRoomStatus,
   })
 
   // 페이지 이탈(뒤로가기/종료) 가드 훅
@@ -90,11 +102,6 @@ export function PvPMatchingPage() {
       joinedRoomId: participantRoomId,
       cleanupMatchingConnection,
     })
-
-  // 실시간 status가 있으면 우선 사용, 없으면 초기 방 상태 사용
-  const latestRoomStatus = liveRoomStatus ?? resolvedRoomDetails?.status ?? null
-
-  const isFinishedStatus = latestRoomStatus === FINISHED_ROOM_STATUS
 
   const {
     isRecording,
@@ -114,12 +121,12 @@ export function PvPMatchingPage() {
   } = usePvPRecordController({
     accessToken,
     roomId: joinedRoomId,
-    roomStatus: latestRoomStatus,
+    roomStatus: currentRoomStatus,
   })
 
-  // 종료 상태 라우팅(main/feedback)과 에러 상태 방 목록 복귀는 전용 훅에서 처리
+  // 종료 상태 라우팅(main/feedback)과 에러 상태 라우팅
   usePvPMatchingRouting({
-    latestRoomStatus,
+    latestRoomStatus: currentRoomStatus,
     participantRoomId,
     roomId,
     shouldRedirectToRooms,
@@ -149,69 +156,31 @@ export function PvPMatchingPage() {
     return <StatusMessage message={PVP_MATCHING_ACCESS_DENIED_MESSAGE} />
   }
 
-  // roomDetails는 이제 null이 아니므로 이후 UI 계산의 기준 객체로 사용한다.
-  // UI 렌더 기준 room status (실시간 우선)
-  const roomStatusForDisplay = liveRoomStatus ?? roomDetails.status
-  const isRecordingStep = roomStatusForDisplay === RECORDING_ROOM_STATUS
-  const isProcessingStep = roomStatusForDisplay === PROCESSING_ROOM_STATUS
+  // 화면 표시용 상태도 소켓 상태를 우선 사용하되, 없으면 서버 상태를 그대로 보여준다.
+  const displayRoomStatus = liveRoomStatus ?? roomDetails.status
 
-  // 참가자 정보 매핑은 JSX에서 반복하지 않도록 상단에서 한 번만 만든다.
-  const leftProfile = {
-    name: roomDetails.host.nickname,
-    avatarUrl: roomDetails.host.profileImageUrl,
-  }
-  const rightProfile = {
-    name: roomDetails.guest?.nickname ?? PVP_MATCHING_EMPTY_GUEST_NAME,
-    avatarUrl: roomDetails.guest?.profileImageUrl ?? '',
-  }
-
-  // OPEN + HOST 상태면 대기 화면(PvPMatchingWaiting) 렌더
-  const isHostWaitingOpenState =
-    roomStatusForDisplay === OPEN_ROOM_STATUS && roomDetails.host.id === myUserId
-  const shouldRenderBattleUi = !isHostWaitingOpenState
-
-  const isHeaderBackDisabled =
-    roomStatusForDisplay === RECORDING_ROOM_STATUS ||
-    roomStatusForDisplay === PROCESSING_ROOM_STATUS ||
-    roomStatusForDisplay === FINISHED_ROOM_STATUS
+  // 참가자 표시용 프로필 shape 변환은 helper에 맡긴다.
+  const { leftProfile, rightProfile } = toPvPParticipantProfiles(roomDetails)
 
   const keywordNameForDisplay =
     thinkingKeywordName ?? roomDetails.keyword?.name ?? PVP_MATCHING_PENDING_KEYWORD_MESSAGE
-  const isThinkingStep = roomStatusForDisplay === THINKING_ROOM_STATUS
 
-  const shouldShowFeedbackLoader =
-    isSubmittingSubmission || isSubmissionCompleted || isProcessingStep || isFinishedStatus
-
-  // 준비 버튼 활성 조건
-  const canStartPvPRecording =
-    isThinkingStep &&
-    Boolean(accessToken) &&
-    Boolean(joinedRoomId) &&
-    !isStartingRecordingRequest &&
-    !isReadySubmitted
-
-  // THINKING 단계에서 준비 버튼을 누르면 서버에 RECORDING 전환을 요청
-  const handleReadyButtonClick = async () => {
-    if (!accessToken || !joinedRoomId) return
-    if (isReadySubmitted || isStartingRecordingRequest) return
-
-    // 중복 클릭 방지 상태 on
-    setIsReadySubmitted(true)
-    setIsStartingRecordingRequest(true)
-    // 서버에 RECORDING 시작 요청
-    const startRecordingResult = await startPvPRecording(accessToken, joinedRoomId)
-    // 요청 종료
-    setIsStartingRecordingRequest(false)
-
-    if (!startRecordingResult.ok) {
-      setIsReadySubmitted(false)
-      toast.error(PVP_START_RECORDING_ERROR_MESSAGE)
-      return
-    }
-
-    // 성공 시 응답 status를 즉시 UI 상태에 반영
-    setLiveRoomStatus(startRecordingResult.data.status)
-  }
+  // status 기반 화면 파생값은 순수 함수에서 한 번에 계산한다.
+  const {
+    isRecordingStep,
+    isProcessingStep,
+    isThinkingStep,
+    isHeaderBackDisabled,
+    isHostWaitingOpenState,
+    shouldRenderBattleUi,
+    shouldShowFeedbackLoader,
+  } = getPvPMatchingUiState({
+    roomStatus: displayRoomStatus,
+    hostUserId: roomDetails.host.id,
+    myUserId,
+    isSubmittingSubmission,
+    isSubmissionCompleted,
+  })
 
   return (
     <div className="flex h-full w-full flex-col gap-4">

--- a/src/features/pvp/index.ts
+++ b/src/features/pvp/index.ts
@@ -12,8 +12,11 @@ export { usePvPRoomCreateExitGuard } from './model/usePvPRoomCreateExitGuard'
 export { usePvPMatchingCreateFlow } from './model/usePvPMatchingCreateFlow'
 export { usePvPMatchingExitGuard } from './model/usePvPMatchingExitGuard'
 export { usePvPMatchingRouting } from './model/usePvPMatchingRouting'
+export { usePvPReadyAction } from './model/usePvPReadyAction'
 export { usePvPMatchingSocket } from './model/usePvPMatchingSocket'
 export { usePvPRecordController } from './model/usePvPRecordController'
+export { getPvPMatchingUiState } from './model/getPvPMatchingUiState'
+export { toPvPParticipantProfiles } from './model/toPvPParticipantProfiles'
 export { getPvPRoomJoinQueryKey, usePvPRoomJoinQuery } from './model/usePvPRoomJoinQuery'
 export { useRoomList } from './model/useRoomList'
 export {
@@ -29,7 +32,6 @@ export {
   PVP_MATCHING_PENDING_KEYWORD_MESSAGE,
   PVP_OPPONENT_SUBMITTED_TOAST_MESSAGE,
   PROCESSING_ROOM_STATUS,
-  PVP_START_RECORDING_ERROR_MESSAGE,
   RECORDING_ROOM_STATUS,
   THINKING_ROOM_STATUS,
 } from './model/pvpMatchingConstants'
@@ -47,8 +49,9 @@ export type {
   PvPRoomStatus,
 } from './api/getPvPRooms'
 export type { JoinPvPRoomResult } from './api/joinPvPRoom'
-export type { StartPvPRecordingResult } from './api/startPvPRecording'
 export type { PvPMatchingAccessState } from './model/usePvPMatchingAccess'
+export type { StartPvPRecordingResult } from './api/startPvPRecording'
+export type { PvPParticipantProfile } from './model/toPvPParticipantProfiles'
 export type {
   CompletePvPSubmissionPayload,
   CompletePvPSubmissionResult,

--- a/src/features/pvp/model/getPvPMatchingUiState.ts
+++ b/src/features/pvp/model/getPvPMatchingUiState.ts
@@ -1,0 +1,53 @@
+import {
+  FINISHED_ROOM_STATUS,
+  OPEN_ROOM_STATUS,
+  PROCESSING_ROOM_STATUS,
+  RECORDING_ROOM_STATUS,
+  THINKING_ROOM_STATUS,
+} from './pvpMatchingConstants'
+
+type GetPvPMatchingUiStateParams = {
+  roomStatus: string | null
+  hostUserId: number
+  myUserId: number | undefined
+  isSubmittingSubmission: boolean
+  isSubmissionCompleted: boolean
+}
+
+type PvPMatchingUiState = {
+  isRecordingStep: boolean
+  isProcessingStep: boolean
+  isThinkingStep: boolean
+  isHostWaitingOpenState: boolean
+  shouldRenderBattleUi: boolean
+  isHeaderBackDisabled: boolean
+  shouldShowFeedbackLoader: boolean
+}
+
+export function getPvPMatchingUiState({
+  roomStatus,
+  hostUserId,
+  myUserId,
+  isSubmittingSubmission,
+  isSubmissionCompleted,
+}: GetPvPMatchingUiStateParams): PvPMatchingUiState {
+  const isRecordingStep = roomStatus === RECORDING_ROOM_STATUS
+  const isProcessingStep = roomStatus === PROCESSING_ROOM_STATUS
+  const isThinkingStep = roomStatus === THINKING_ROOM_STATUS
+  const isHostWaitingOpenState = roomStatus === OPEN_ROOM_STATUS && hostUserId === myUserId
+  const shouldRenderBattleUi = !isHostWaitingOpenState
+  const isFinishedStep = roomStatus === FINISHED_ROOM_STATUS
+  const isHeaderBackDisabled = isRecordingStep || isProcessingStep || isFinishedStep
+  const shouldShowFeedbackLoader =
+    isSubmittingSubmission || isSubmissionCompleted || isProcessingStep || isFinishedStep
+
+  return {
+    isRecordingStep,
+    isProcessingStep,
+    isThinkingStep,
+    isHostWaitingOpenState,
+    shouldRenderBattleUi,
+    isHeaderBackDisabled,
+    shouldShowFeedbackLoader,
+  }
+}

--- a/src/features/pvp/model/toPvPParticipantProfiles.ts
+++ b/src/features/pvp/model/toPvPParticipantProfiles.ts
@@ -1,0 +1,46 @@
+import { PVP_MATCHING_EMPTY_GUEST_NAME } from './pvpMatchingConstants'
+
+import type { PvPCardDetails } from '@/entities/pvp-card'
+import type { PvPRoomDetails } from '@/entities/room'
+
+export type PvPParticipantProfile = {
+  name: string
+  avatarUrl?: string
+}
+
+type PvPParticipantProfiles = {
+  leftProfile: PvPParticipantProfile
+  rightProfile: PvPParticipantProfile
+}
+
+type PvPParticipantSource = PvPRoomDetails | PvPCardDetails
+
+function isRoomDetails(source: PvPParticipantSource): source is PvPRoomDetails {
+  return 'host' in source
+}
+
+export function toPvPParticipantProfiles(source: PvPParticipantSource): PvPParticipantProfiles {
+  if (isRoomDetails(source)) {
+    return {
+      leftProfile: {
+        name: source.host.nickname,
+        avatarUrl: source.host.profileImageUrl,
+      },
+      rightProfile: {
+        name: source.guest?.nickname ?? PVP_MATCHING_EMPTY_GUEST_NAME,
+        avatarUrl: source.guest?.profileImageUrl ?? '',
+      },
+    }
+  }
+
+  return {
+    leftProfile: {
+      name: source.myResult?.user?.nickname ?? '',
+      avatarUrl: source.myResult?.user?.profileImageUrl ?? '',
+    },
+    rightProfile: {
+      name: source.opponentResult?.user?.nickname ?? '',
+      avatarUrl: source.opponentResult?.user?.profileImageUrl ?? '',
+    },
+  }
+}

--- a/src/features/pvp/model/usePvPReadyAction.ts
+++ b/src/features/pvp/model/usePvPReadyAction.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+
+import { startPvPRecording } from '../api/startPvPRecording'
+
+import { PVP_START_RECORDING_ERROR_MESSAGE, THINKING_ROOM_STATUS } from './pvpMatchingConstants'
+
+type UsePvPReadyActionParams = {
+  accessToken: string | null
+  roomId: number | null
+  roomStatus: string | null
+  isReadySubmitted: boolean
+  setIsReadySubmitted: (nextValue: boolean) => void
+  onReadySuccess: (nextStatus: string | null) => void
+}
+
+type UsePvPReadyActionResult = {
+  isStartingRecordingRequest: boolean
+  canStartPvPRecording: boolean
+  handleReadyButtonClick: () => Promise<void>
+}
+
+export function usePvPReadyAction({
+  accessToken,
+  roomId,
+  roomStatus,
+  isReadySubmitted,
+  setIsReadySubmitted,
+  onReadySuccess,
+}: UsePvPReadyActionParams): UsePvPReadyActionResult {
+  const [isStartingRecordingRequest, setIsStartingRecordingRequest] = useState(false)
+
+  const canStartPvPRecording =
+    roomStatus === THINKING_ROOM_STATUS &&
+    Boolean(accessToken) &&
+    Boolean(roomId) &&
+    !isStartingRecordingRequest &&
+    !isReadySubmitted
+
+  const handleReadyButtonClick = useCallback(async () => {
+    if (!accessToken || !roomId) return
+    if (isReadySubmitted || isStartingRecordingRequest) return
+
+    setIsReadySubmitted(true)
+    setIsStartingRecordingRequest(true)
+
+    const startRecordingResult = await startPvPRecording(accessToken, roomId)
+
+    setIsStartingRecordingRequest(false)
+
+    if (!startRecordingResult.ok) {
+      setIsReadySubmitted(false)
+      toast.error(PVP_START_RECORDING_ERROR_MESSAGE)
+      return
+    }
+
+    onReadySuccess(startRecordingResult.data.status)
+  }, [
+    accessToken,
+    isReadySubmitted,
+    isStartingRecordingRequest,
+    onReadySuccess,
+    roomId,
+    setIsReadySubmitted,
+  ])
+
+  return {
+    isStartingRecordingRequest,
+    canStartPvPRecording,
+    handleReadyButtonClick,
+  }
+}

--- a/src/features/pvp/ui/PvPMatchingWaiting.tsx
+++ b/src/features/pvp/ui/PvPMatchingWaiting.tsx
@@ -5,15 +5,12 @@ import { CircleCheckBig } from 'lucide-react'
 import { Spinner } from '@/shared'
 
 import { PvPParticipants } from './PvPParticipants'
+
+import type { PvPParticipantProfile } from './PvPParticipants'
+
 type PvPMatchingWaitingProps = {
-  leftProfile: {
-    name: string
-    avatarUrl?: string
-  }
-  rightProfile: {
-    name: string
-    avatarUrl?: string
-  }
+  leftProfile: PvPParticipantProfile
+  rightProfile: PvPParticipantProfile
   showSpinner?: boolean
 }
 

--- a/src/features/pvp/ui/PvPParticipants.tsx
+++ b/src/features/pvp/ui/PvPParticipants.tsx
@@ -2,10 +2,9 @@
 
 import { PvPProfile } from './PvPProfile'
 
-type PvPParticipantProfile = {
-  name: string
-  avatarUrl?: string
-}
+import type { PvPParticipantProfile } from '../model/toPvPParticipantProfiles'
+
+export type { PvPParticipantProfile } from '../model/toPvPParticipantProfiles'
 
 type PvPParticipantsProps = {
   leftProfile: PvPParticipantProfile

--- a/src/widgets/pvp-feedback/ui/PvPFeedbackView.tsx
+++ b/src/widgets/pvp-feedback/ui/PvPFeedbackView.tsx
@@ -4,7 +4,7 @@ import { useParams, useRouter } from 'next/navigation'
 
 import { PvPCategory, PvPKeyword, usePvPCardDetails } from '@/entities/pvp-card'
 import { useAccessToken } from '@/features/auth'
-import { PvPParticipants, PvPProfile } from '@/features/pvp'
+import { PvPParticipants, PvPProfile, toPvPParticipantProfiles } from '@/features/pvp'
 import { PvPFeedbackPanel, PvPWinnerProfileCard } from '@/features/pvp-feedback'
 import { ModeHeader, StatusMessage } from '@/shared'
 
@@ -58,6 +58,8 @@ export function PvPFeedbackView({ variant, roomId, messages }: PvPFeedbackViewPr
     return <StatusMessage message={messages?.empty ?? DEFAULT_EMPTY_MESSAGE} />
   }
 
+  const { leftProfile, rightProfile } = toPvPParticipantProfiles(details)
+
   const handleBackClick = () => {
     if (variant === 'matching') {
       router.replace(MAIN_PAGE_PATH)
@@ -77,14 +79,8 @@ export function PvPFeedbackView({ variant, roomId, messages }: PvPFeedbackViewPr
       />
       <PvPCategory categoryName={details.category?.name ?? ''} />
       <PvPParticipants
-        leftProfile={{
-          name: details.myResult?.user?.nickname ?? '',
-          avatarUrl: details.myResult?.user?.profileImageUrl ?? '',
-        }}
-        rightProfile={{
-          name: details.opponentResult?.user?.nickname ?? '',
-          avatarUrl: details.opponentResult?.user?.profileImageUrl ?? '',
-        }}
+        leftProfile={leftProfile}
+        rightProfile={rightProfile}
       />
       <PvPKeyword keywordName={details.keyword?.name ?? ''} />
       <PvPWinnerProfileCard


### PR DESCRIPTION
## 개요
* `PvPMatchingPage`의 오케스트레이션 로직을 정리해 **페이지는 조합 중심**, 로직은 **훅/헬퍼 함수로 분리**
* 준비 버튼 액션(`startPvPRecording`)을 전용 훅으로 분리해 **중복 클릭 방지/토스트 처리/상태 반영/활성 조건 계산**을 캡슐화
* 매칭 UI 상태 계산 및 참가자 프로필 매핑을 헬퍼로 분리하고, `PvPFeedbackView`에서도 동일 매퍼를 재사용해 **중복 제거 + 타입 일관성**을 강화

---

## 변경사항

### 1) `PvPMatchingPage` 오케스트레이션 정리
* 파일: `src/_pages/pvp/matching/ui/PvPMatchingPage.tsx`
* 내용:
  * 준비 버튼 액션을 페이지 밖으로 분리
  * 상태 기반 UI 계산을 helper로 분리
  * 참가자 프로필 매핑을 helper로 분리
  * 소켓 콜백에 이름 부여(가독성 개선)
  * `currentRoomStatus` / `displayRoomStatus`로 네이밍 정리

### 2) 준비 버튼 액션 훅 분리
* 파일: `src/features/pvp/model/usePvPReadyAction.ts`
* 내용:
  * `startPvPRecording` 요청 처리
  * 중복 클릭 방지
  * 실패 시 toast 처리
  * 성공 시 상태 반영
  * 준비 버튼 활성 조건 계산

### 3) PvP 매칭 UI 상태 계산 분리
* 파일: `src/features/pvp/model/getPvPMatchingUiState.ts`
* 포함 계산:
  * `isRecordingStep`, `isProcessingStep`, `isThinkingStep`
  * `isHostWaitingOpenState`
  * `shouldRenderBattleUi`
  * `isHeaderBackDisabled`
  * `shouldShowFeedbackLoader`
* `isFinishedStatus` 직접 계산/반환은 제거(필요한 파생값만 반환)

### 4) 참가자 프로필 매핑 함수 분리 + 재사용
* 파일: `src/features/pvp/model/toPvPParticipantProfiles.ts`
* 내용:
  * `PvPRoomDetails` + `PvPCardDetails` 입력을 받아
    * `leftProfile`, `rightProfile` 형태로 변환
* 적용:
  * `PvPMatchingPage`에서 사용
  * `PvPFeedbackView`에서도 재사용 적용(직접 매핑 제거)
    * `src/widgets/pvp-feedback/ui/PvPFeedbackView.tsx`

### 5) 관련 UI 타입/Export 정리
* 파일:
  * `src/features/pvp/ui/PvPParticipants.tsx`
  * `src/features/pvp/ui/PvPMatchingWaiting.tsx`
  * `src/features/pvp/index.ts`
* 내용:
  * `PvPParticipantProfile` 타입 재사용
  * public API export 정리

### 6) 기타
* `next.config.mjs` 변경 포함(해당 커밋에 포함)

---

## Screenshots (UI 변경 시)

---

## How to test

1. 설치/실행 및 검증

* `pnpm i`
* `pnpm lint`
* `pnpm build`
* `pnpm dev`

2. PvP 매칭 페이지 동작 확인

* `/pvp/matching/{roomId}` 진입
* 상태 전환에 따라 UI가 동일하게 동작하는지 확인
  * THINKING / RECORDING / PROCESSING / FINISHED 등

3. 준비 버튼 액션 확인

* 준비 버튼 클릭 시 `startPvPRecording`이 호출되는지 확인
* 빠르게 여러 번 클릭해도 **중복 요청이 발생하지 않는지** 확인
* 실패 시 toast가 정상적으로 노출되는지 확인
* 성공 시 상태/UI가 정상 반영되는지 확인
* 준비 버튼 활성/비활성 조건이 의도대로 계산되는지 확인

4. 참가자 프로필 매핑/표시 확인

* 매칭 페이지에서 좌/우 참가자 프로필이 올바르게 표시되는지 확인
* 피드백 페이지에서도 동일 매핑 로직이 적용되어 표시가 정상인지 확인

---

## 참고 커밋

* `7e5b13a` refactor: pvp matching page flow
