### PR TITLE
fix: room name length

### DIFF
--- a/src/features/pvp/model/usePvPMatchingCreateFlow.ts
+++ b/src/features/pvp/model/usePvPMatchingCreateFlow.ts
@@ -18,6 +18,8 @@ import type { CategoryItemType } from '@/entities/category'
 const CREATE_ROOM_ERROR_MESSAGE = '방을 만들던 중 오류가 발생하였습니다.'
 // 생성 성공 후 이동할 경로 prefix
 const MATCHING_PATH_PREFIX = '/pvp/matching'
+// 방 이름 최대 길이
+const MAX_ROOM_NAME_LENGTH = 10
 
 // 방 이름 앞/뒤 공백 제거 유틸(중간 공백은 유지)
 const normalizeRoomNameBoundarySpaces = (value: string) => value.trim()
@@ -66,13 +68,16 @@ export function usePvPMatchingCreateFlow({
 
   const hasSelectedCategory = Boolean(selectedCategory)
   const isCategoryStep = !isNextClicked
+  const normalizedRoomName = normalizeRoomNameBoundarySpaces(roomName)
+  const isRoomNameEmpty = normalizedRoomName.length === 0
+  const isRoomNameTooLong = normalizedRoomName.length > MAX_ROOM_NAME_LENGTH
 
   const createButtonVariant = isCategoryStep ? 'category' : 'create'
 
   // 단계별 유효성 검증:
   // - 1단계: 카테고리 필수
-  // - 2단계: trim 기준 방 이름 필수
-  const isFormInvalid = isCategoryStep ? !hasSelectedCategory : roomName.trim().length === 0
+  // - 2단계: trim 기준 방 이름 필수 + 10자 이하
+  const isFormInvalid = isCategoryStep ? !hasSelectedCategory : isRoomNameEmpty || isRoomNameTooLong
   // 버튼 비활성 최종 조건
   const isCreateButtonDisabled = isFormInvalid || isCreatingRoom
 
@@ -106,7 +111,7 @@ export function usePvPMatchingCreateFlow({
     }
 
     // 카테고리는 선택했지만 방 이름이 비어 있으면 카테고리 선택 해제
-    if (roomName.trim().length === 0) {
+    if (isRoomNameEmpty) {
       setSelectedCategory(null)
       setIsNextClicked(null)
       return
@@ -116,7 +121,7 @@ export function usePvPMatchingCreateFlow({
     setRoomName('')
     setSelectedCategory(null)
     setIsNextClicked(null)
-  }, [isCreatingRoom, roomName, router, selectedCategory])
+  }, [isCreatingRoom, isRoomNameEmpty, router, selectedCategory])
 
   // 생성 진행 상태를 부모 페이지와 동기화(헤더 back 비활성화에 사용)
   useEffect(() => {
@@ -139,8 +144,7 @@ export function usePvPMatchingCreateFlow({
     if (!accessToken || !selectedCategory) return
 
     // 방 이름 정규화
-    const normalizedRoomName = normalizeRoomNameBoundarySpaces(roomName)
-    if (normalizedRoomName.length === 0) return
+    if (isRoomNameEmpty || isRoomNameTooLong) return
 
     // 생성 요청 중복 방지
     if (isCreatingRoom) return

--- a/src/features/pvp/ui/RoomNameSetting.tsx
+++ b/src/features/pvp/ui/RoomNameSetting.tsx
@@ -45,6 +45,7 @@ export function RoomNameSetting({
             onChange={(event) => onRoomNameChange(event.target.value)}
             onBlur={onRoomNameBlur}
             disabled={disabled}
+            maxLength={10}
           />
           <FieldDescription>방 이름은 1자 이상 10자 이하로 입력해주세요.</FieldDescription>
           <FieldDescription>비방/욕설이 담긴 단어는 포함하실 수 없습니다.</FieldDescription>


### PR DESCRIPTION
## 개요
* PvP 방 생성 시 **방 이름 최대 길이(10자)** 규칙을 적용해 입력 단계와 생성 로직 검증을 일치시킴
* 사용자가 10자를 초과한 방 이름으로 **입력/생성 요청을 보내지 못하도록** UI/로직 양쪽에서 방어

---

## 변경사항
### 1) 생성 플로우에 방 이름 길이 검증 반영
* 파일: `src/features/pvp/model/usePvPMatchingCreateFlow.ts`
* 내용:
  * `MAX_ROOM_NAME_LENGTH = 10` 상수 추가
  * roomName을 `trim`으로 정규화 후 검증
    * 비어 있으면 invalid
    * 10자 초과면 invalid
  * `방 만들기` 버튼 비활성 조건을 동일 규칙으로 변경
  * `createPvPRoom` 호출 직전에도 동일 조건으로 한 번 더 차단(이중 방어)

### 2) 입력 자체를 10자로 제한
* 파일: `src/features/pvp/ui/RoomNameSetting.tsx`
* 내용:
  * `Input`에 `maxLength={10}` 추가

---

## Screenshots (UI 변경 시)

---

## How to test

1. 실행

* `pnpm i`
* `pnpm dev`

2. 방 이름 검증 확인

* PvP 방 생성 화면 진입
* 케이스별 확인:
  * 공백만 입력(`"   "`): `trim` 후 빈 값 → 버튼 비활성 & 생성 차단
  * 10자 입력: 정상 입력/버튼 활성/생성 가능
  * 11자 이상 입력: 입력이 10자에서 멈추는지(`maxLength`) 확인
* 개발자 도구로 강제로 10자 초과 값을 넣는 경우에도,
  * `createPvPRoom` 호출 직전에 동일 검증으로 차단되는지 확인

---

## 참고 커밋
* `70c2d28` fix: room name length
