### PR TITLE
Fix/win count render

### DIFF
--- a/src/entities/user/model/useSyncMyProfile.ts
+++ b/src/entities/user/model/useSyncMyProfile.ts
@@ -25,6 +25,14 @@ export function useSyncMyProfile({ accessToken, myProfile }: UseSyncMyProfilePar
     }
   }
 
+  const hasSameProfileFields =
+    profile.id === myProfile?.id &&
+    profile.nickname === myProfile?.nickname &&
+    profile.level === myProfile?.level &&
+    profile.activeCardCount === myProfile?.activeCardCount &&
+    profile.consecutiveDays === myProfile?.consecutiveDays &&
+    profile.winCount === myProfile?.winCount
+
   // store 동기화는 "필요할 때만" (그리고 같은 값이면 안 넣기)
   useEffect(() => {
     // 토큰/데이터 없으면 동기화하지 않음
@@ -32,17 +40,17 @@ export function useSyncMyProfile({ accessToken, myProfile }: UseSyncMyProfilePar
     // 이미 같은 프로필이면 불필요한 상태 업데이트 방지
     const curBase = stripQuery(profile.profileImageUrl)
     const nextBase = stripQuery(myProfile.profileImageUrl)
+    const hasSameImageBase = Boolean(curBase) && curBase === nextBase
 
-    // ✅ 같은 유저 + 같은 파일이면(쿼리만 다른 presigned) store 업데이트 금지
-    if (profile.id === myProfile.id && curBase && curBase === nextBase) {
+    // 프로필의 실질 데이터와 이미지 파일 base가 모두 같을 때만 store 업데이트를 생략한다.
+    if (hasSameProfileFields && hasSameImageBase) {
       return
     }
 
-    // ✅ 업데이트는 하되, 같은 파일이면 기존 URL을 유지(= src swap 방지)
+    // 같은 파일의 presigned URL만 바뀐 경우에는 기존 URL을 유지해 불필요한 src swap을 줄인다.
     setProfile({
       ...myProfile,
-      profileImageUrl:
-        curBase && curBase === nextBase ? profile.profileImageUrl : myProfile.profileImageUrl,
+      profileImageUrl: hasSameImageBase ? profile.profileImageUrl : myProfile.profileImageUrl,
     })
-  }, [accessToken, myProfile, profile.id, profile.profileImageUrl, setProfile])
+  }, [accessToken, hasSameProfileFields, myProfile, profile.profileImageUrl, setProfile])
 }

--- a/src/widgets/profile/ui/ProfileDashboard.tsx
+++ b/src/widgets/profile/ui/ProfileDashboard.tsx
@@ -32,14 +32,13 @@ export function ProfileDashboard({
   const profile = useProfile()
   const { data: myProfile } = useMyProfileQuery(accessToken, { enabled: Boolean(accessToken) })
   useSyncMyProfile({ accessToken, myProfile })
+  const resolvedProfile = myProfile ?? profile
 
   const isMainPage = pathname === MAIN_PAGE_PATH
   const isMyPage = pathname === MY_PAGE_PATH
-  const isProfileReady = Boolean(profile.nickname || profile.profileImageUrl)
+  const isProfileReady = Boolean(resolvedProfile.nickname || resolvedProfile.profileImageUrl)
   const shouldDeferAvatarImage = deferAvatarImageUntilProfileReady && !myProfile
-  const avatarSrcForRender = shouldDeferAvatarImage
-    ? ''
-    : (myProfile?.profileImageUrl ?? profile.profileImageUrl)
+  const avatarSrcForRender = shouldDeferAvatarImage ? '' : resolvedProfile.profileImageUrl
 
   return (
     <div className="relative w-full">
@@ -69,13 +68,13 @@ export function ProfileDashboard({
               size={AVATAR_SIZE_PX}
             />
           </div>
-          <Nickname nickname={isProfileReady ? profile.nickname : FALLBACK_NICKNAME} />
+          <Nickname nickname={isProfileReady ? resolvedProfile.nickname : FALLBACK_NICKNAME} />
         </div>
 
         <StatCards
-          cardCount={isProfileReady ? profile.activeCardCount : FALLBACK_STAT_VALUE}
-          winCount={isProfileReady ? profile.winCount : FALLBACK_STAT_VALUE}
-          levelCount={isProfileReady ? profile.level : FALLBACK_STAT_VALUE}
+          cardCount={isProfileReady ? resolvedProfile.activeCardCount : FALLBACK_STAT_VALUE}
+          winCount={isProfileReady ? resolvedProfile.winCount : FALLBACK_STAT_VALUE}
+          levelCount={isProfileReady ? resolvedProfile.level : FALLBACK_STAT_VALUE}
         />
       </div>
     </div>


### PR DESCRIPTION
## 개요
* `ProfileDashboard`에서 **승리 수(winCount) 등 프로필 주요 정보가 최신 `/users/me(myProfile)` 응답으로 갱신되지 않던 문제**를 수정
* 화면 렌더는 **query 데이터(`myProfile`)를 우선** 사용하도록 통합
* `useSyncMyProfile`의 store 업데이트 생략 조건을 “이미지 base URL만”이 아니라 **주요 필드까지 동일한 경우에만** 생략하도록 보강

---

## 변경사항
### 1) `ProfileDashboard`가 최신 프로필 데이터를 우선 렌더
* 파일: `src/widgets/profile/ui/ProfileDashboard.tsx`
* 내용:
  * 렌더 기준을 `resolvedProfile = myProfile ?? profile`로 통합
  * 닉네임/카드 수/승리 수/레벨 등은 **query 데이터가 있으면 우선 사용**
* 의도:
  * store 동기화가 늦거나 조건부로 생략되더라도, 화면은 `/users/me`의 최신 값을 즉시 반영

### 2) `useSyncMyProfile` store 업데이트 생략 조건 보강
* 파일: `src/entities/user/model/useSyncMyProfile.ts`
* 내용:
  * 기존: “이미지 base URL이 같으면” store 업데이트 생략
  * 변경: **프로필 주요 필드가 모두 같고 + 이미지 base URL도 같을 때만** 업데이트 생략
  * 비교 필드:
    * `id`, `nickname`, `level`, `activeCardCount`, `consecutiveDays`, `winCount`
* 의도:
  * presigned URL만 달라지는 경우엔 불필요한 `src swap`을 줄이되,
  * `winCount` 등 이미지 외 필드가 변경되면 **정상적으로 store에 반영**

---

## 해결된 문제
* `/users/me` 응답에는 최신 `winCount`가 내려오지만,
* 이미지 base URL이 같다는 이유로 store 업데이트가 생략되어
* `ProfileDashboard`에서 승리 수가 갱신되지 않던 문제를 해결

---

## Screenshots (UI 변경 시)

---

## How to test

1. 실행/검증

* `pnpm i`
* `pnpm lint`
* `pnpm build`
* `pnpm dev`

2. 승리 수 갱신 확인

* 로그인 후 `/main` 또는 `/mypage`에서 `ProfileDashboard`의 승리 수 확인
* 승리 수가 변경되는 시나리오(예: PvP 결과 반영 후, 또는 `myProfile` invalidate/refetch) 수행
* 다음을 확인:

  * `/users/me` 응답의 `winCount`가 UI에 즉시 반영되는지 (`myProfile` 우선 렌더)
  * 이미지 base URL은 같지만 `winCount`가 변한 경우 store 업데이트가 생략되지 않는지

---

## 참고 커밋

* `e4b26be` fix: fix profile load cache condition
