### PR TITLE
fix: mypage card details page header

### DIFF
--- a/src/app/(protected)/mypage/layout.tsx
+++ b/src/app/(protected)/mypage/layout.tsx
@@ -1,0 +1,11 @@
+import { MenuVisibleLayout } from '@/widgets/layouts'
+
+import type { ReactNode } from 'react'
+
+type MyPageLayoutProps = {
+  children: ReactNode
+}
+
+export default function MyPageLayout({ children }: MyPageLayoutProps) {
+  return <MenuVisibleLayout>{children}</MenuVisibleLayout>
+}


### PR DESCRIPTION
## 개요
* `mypage/cards/[id]`, `mypage/pvps/[id]` 상세 페이지에서 **공통 헤더가 렌더되지 않던 문제**를 수정
* `/mypage` 하위 상세 라우트가 `ProfilePagesLayout`/`MenuVisibleLayout`을 타지 않던 것이 원인이었고, `mypage` 라우트 전용 layout을 추가해 **하위 라우트를 `MenuVisibleLayout`으로 감싸도록** 구성

---

## 변경사항
* `src/app/(protected)/mypage/layout.tsx` 추가
  * `mypage` 하위 라우트를 `MenuVisibleLayout`으로 감싸서 공통 헤더가 항상 표시되도록 수정
```tsx
export default function MyPageLayout({ children }: MyPageLayoutProps) {
  return <MenuVisibleLayout>{children}</MenuVisibleLayout>
}
```

---

## Screenshots (UI 변경 시)
* `/mypage/cards/[id]` 헤더 표시 before/after
* `/mypage/pvps/[id]` 헤더 표시 before/after

---

## How to test

1. 설치 및 실행

* `pnpm i`
* `pnpm lint`
* `pnpm build`
* `pnpm dev`

2. 동작 확인

* 로그인 후 아래 경로로 진입

  * `/mypage/cards/[id]`
  * `/mypage/pvps/[id]`
* 두 상세 페이지에서 **공통 헤더가 정상적으로 렌더링되는지** 확인
* 기존 `/mypage` 및 다른 protected 페이지에서 헤더/레이아웃이 깨지지 않는지 회귀 확인

---

## 기대 효과

* `mypage` 하위 상세 페이지에서도 공통 헤더가 **일관되게 표시**
* 상세 페이지별 헤더 개별 삽입이 필요 없어져 **구조 단순화 및 유지보수성 향상**

---

## 참고 커밋

* `de89018` fix: mypage card details page header
