### PR TITLE
Test/e2e pvp flow

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import globals from 'globals'
 const FILES_TO_LINT = ['**/*.{ts,tsx,js,jsx}']
 
 const config = [
-  { ignores: ['node_modules/*', 'dist/', '.vite/', '.next/'] },
+  { ignores: ['node_modules/*', 'dist/', '.vite/', '.next/', '.next-3001/'] },
   ...nextConfig,
   ...tseslint.configs['flat/recommended'],
   {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
+import './.next/dev/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,9 +15,6 @@ const nextConfig = {
   output: 'standalone',
   ...(customDistDir ? { distDir: customDistDir } : {}),
   productionBrowserSourceMaps: true,
-  experimental: {
-    trustHostHeader: true,
-  },
   images: {
     dangerouslyAllowLocalIP: true,
     formats: ['image/avif', 'image/webp'],

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -1,12 +1,18 @@
 import { defineConfig, devices } from '@playwright/test'
 
-const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3001'
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000'
+const E2E_WEB_SERVER_COMMAND = 'pnpm dev'
+const E2E_WEB_SERVER_TIMEOUT_MS = 120_000
+const E2E_WORKER_COUNT = 1
+const E2E_STORAGE_STATE_PATH = 'playwright/.auth/e2e-user.json'
 
 // E2E_BASE_URL이 없으면 로컬 서버를 자동 실행
 const shouldStartServer = !process.env.E2E_BASE_URL
 
 export default defineConfig({
   testDir: './tests/e2e',
+  workers: E2E_WORKER_COUNT,
+  globalSetup: './tests/e2e/global-setup.ts',
 
   // ✅ 테스트 1개당 최대 실행 시간
   timeout: 60_000,
@@ -17,6 +23,7 @@ export default defineConfig({
   // ✅ 모든 테스트에 공통 적용되는 옵션
   use: {
     baseURL,
+    storageState: E2E_STORAGE_STATE_PATH,
 
     // ✅ 재시도 1회차에서 실패하면 트레이스를 남겨서 디버깅을 쉽게 함
     trace: 'on-first-retry',
@@ -38,9 +45,10 @@ export default defineConfig({
   // 로컬에서 E2E 실행 시 Playwright가 Next 서버를 자동 실행
   webServer: shouldStartServer
     ? {
-        command: 'pnpm dev -p 3001',
+        command: E2E_WEB_SERVER_COMMAND,
         url: baseURL,
         reuseExistingServer: !process.env.CI,
+        timeout: E2E_WEB_SERVER_TIMEOUT_MS,
       }
     : undefined,
 })

--- a/playwright/.auth/e2e-user.json
+++ b/playwright/.auth/e2e-user.json
@@ -1,0 +1,35 @@
+{
+  "cookies": [
+    {
+      "name": "refresh_token",
+      "value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNzcyNTM0ODM0LCJleHAiOjE3NzMxMzk2MzR9.h32Ee2GyhbooNYbilzi7mesr8bHDJq8rpV7teNJvjCM",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": true,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "e2e_access_token",
+      "value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNzcyNTM0ODM0LCJleHAiOjE3NzI1Mzg0MzR9.GKmeL1WWDaQUpcdlMAHiHNHzd2a9nr07UKR1N4_m0S4",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "e2e_access_token_expires_at",
+      "value": "3600",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": []
+}

--- a/src/app/(public)/api/auth/refresh/route.ts
+++ b/src/app/(public)/api/auth/refresh/route.ts
@@ -5,6 +5,8 @@ import { NextResponse } from 'next/server'
 import { httpClient } from '@/shared/api'
 
 const REFRESH_TOKEN_COOKIE = 'refresh_token'
+const E2E_ACCESS_TOKEN_COOKIE = 'e2e_access_token'
+const E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE = 'e2e_access_token_expires_at'
 const COOKIE_PATH = '/'
 
 const clearRefreshTokenCookie = (res: NextResponse) => {
@@ -18,7 +20,19 @@ const clearRefreshTokenCookie = (res: NextResponse) => {
 }
 
 export async function POST() {
-  const refreshToken = (await cookies()).get('refresh_token')?.value
+  const cookieStore = await cookies()
+  const e2eAccessToken = cookieStore.get(E2E_ACCESS_TOKEN_COOKIE)?.value
+  const e2eAccessTokenExpiresAt = cookieStore.get(E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE)?.value
+
+  // E2E에서는 refresh token 회전/무효화 정책과 분리해 access token만으로 테스트를 안정화한다.
+  if (process.env.ALLOW_E2E_LOGIN === 'true' && e2eAccessToken) {
+    return NextResponse.json({
+      access_token: e2eAccessToken,
+      expiresIn: Number(e2eAccessTokenExpiresAt) || 0,
+    })
+  }
+
+  const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value
 
   if (!refreshToken) {
     const res = NextResponse.json({ error: 'no_refresh_token' }, { status: 401 })

--- a/src/app/(public)/api/e2e/login/route.ts
+++ b/src/app/(public)/api/e2e/login/route.ts
@@ -6,6 +6,9 @@ const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://dev.imy
 
 // ✅ middleware(proxy.ts)에서 확인하는 쿠키 이름과 반드시 동일
 const REFRESH_TOKEN_COOKIE = 'refresh_token'
+const E2E_ACCESS_TOKEN_COOKIE = 'e2e_access_token'
+const E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE = 'e2e_access_token_expires_at'
+const E2E_ACCESS_TOKEN_FALLBACK_EXPIRES_IN_MS = 10 * 60 * 1000
 
 export async function POST(req: Request) {
   // ✅ 운영에 노출 방지 (명시 플래그로만 허용)
@@ -17,6 +20,7 @@ export async function POST(req: Request) {
 
   let accessToken = ''
   let refreshToken = ''
+  let expiresIn = 0
 
   try {
     const response = await httpClient.post(
@@ -28,9 +32,12 @@ export async function POST(req: Request) {
       },
     )
 
-    const data = response.data?.data as { accessToken: string; refreshToken: string } | undefined
+    const data = response.data?.data as
+      | { accessToken: string; refreshToken: string; expiresIn?: number }
+      | undefined
     accessToken = data?.accessToken ?? ''
     refreshToken = data?.refreshToken ?? ''
+    expiresIn = data?.expiresIn ?? 0
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error'
     return NextResponse.json({ message: 'E2E login failed', detail: message }, { status: 500 })
@@ -53,6 +60,25 @@ export async function POST(req: Request) {
     httpOnly: true,
     sameSite: 'lax',
     secure: false, // 로컬 http면 false (https면 true)
+    path: '/',
+  })
+
+  const accessTokenExpiresAtMs =
+    expiresIn > 0 ? expiresIn : Date.now() + E2E_ACCESS_TOKEN_FALLBACK_EXPIRES_IN_MS
+
+  // E2E에서는 첫 페이지 진입 전에 access token을 클라이언트 store로 바로 올릴 수 있도록
+  // non-httpOnly 쿠키로도 함께 심어둔다.
+  res.cookies.set(E2E_ACCESS_TOKEN_COOKIE, accessToken, {
+    httpOnly: false,
+    sameSite: 'lax',
+    secure: false,
+    path: '/',
+  })
+
+  res.cookies.set(E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE, String(accessTokenExpiresAtMs), {
+    httpOnly: false,
+    sameSite: 'lax',
+    secure: false,
     path: '/',
   })
 

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from 'next/server'
 import { register, Histogram } from 'prom-client'
 
+const ACCEPTED_STATUS_CODE = 202
+const BAD_REQUEST_STATUS_CODE = 400
+const INTERNAL_SERVER_ERROR_STATUS_CODE = 500
+const EMPTY_BODY_TEXT = 'Metric request body is empty'
+const METRIC_ACCEPTED_TEXT = 'Metric received'
+const INVALID_METRIC_PAYLOAD_TEXT = 'Invalid metric payload'
+const METRIC_ERROR_TEXT = 'Error receiving metric'
+
 // NOTE: prom-client creates a global registry by default.
 // This is okay for single-process applications like a Next.js server.
 
@@ -66,7 +74,7 @@ export async function GET() {
     })
   } catch (error) {
     console.error('Error getting metrics:', error)
-    return new NextResponse('Error getting metrics', { status: 500 })
+    return new NextResponse('Error getting metrics', { status: INTERNAL_SERVER_ERROR_STATUS_CODE })
   }
 }
 
@@ -76,7 +84,19 @@ export async function GET() {
  */
 export async function POST(request: Request) {
   try {
-    const { name, value } = await request.json()
+    const requestBody = await request.text()
+
+    if (!requestBody.trim()) {
+      return new NextResponse(EMPTY_BODY_TEXT, { status: ACCEPTED_STATUS_CODE })
+    }
+
+    const payload = JSON.parse(requestBody) as { name?: string; value?: number }
+    const { name, value } = payload
+
+    if (!name || typeof value !== 'number') {
+      return new NextResponse(INVALID_METRIC_PAYLOAD_TEXT, { status: BAD_REQUEST_STATUS_CODE })
+    }
+
     const histogram = histograms[name]
 
     if (histogram) {
@@ -86,9 +106,9 @@ export async function POST(request: Request) {
       console.warn(`Received unknown metric: ${name}`)
     }
 
-    return new NextResponse('Metric received', { status: 202 })
+    return new NextResponse(METRIC_ACCEPTED_TEXT, { status: ACCEPTED_STATUS_CODE })
   } catch (error) {
     console.error('Error receiving metric:', error)
-    return new NextResponse('Error receiving metric', { status: 400 })
+    return new NextResponse(METRIC_ERROR_TEXT, { status: BAD_REQUEST_STATUS_CODE })
   }
 }

--- a/src/features/provider/ui/AuthBootStrap.tsx
+++ b/src/features/provider/ui/AuthBootStrap.tsx
@@ -14,10 +14,25 @@ const REFRESH_PATH = '/api/auth/refresh'
 const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL ?? ''
 const REFRESH_LEEWAY_SECONDS = 60
 const REFRESH_LEEWAY_MS = REFRESH_LEEWAY_SECONDS * 1000
+const E2E_ACCESS_TOKEN_COOKIE = 'e2e_access_token'
+const E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE = 'e2e_access_token_expires_at'
 
 const buildServerUrl = (path: string) => {
   const normalizedBase = SERVER_URL.replace(/\/$/, '')
   return `${normalizedBase}${path}`
+}
+
+const getCookieValue = (cookieName: string) => {
+  if (typeof document === 'undefined') return ''
+
+  const cookiePrefix = `${cookieName}=`
+  const cookieValue = document.cookie.split('; ').find((cookie) => cookie.startsWith(cookiePrefix))
+
+  if (!cookieValue) {
+    return ''
+  }
+
+  return decodeURIComponent(cookieValue.slice(cookiePrefix.length))
 }
 
 const getRefreshDelayMs = (accessTokenExpiresAtMs: number) => {
@@ -76,6 +91,20 @@ export function AuthBootstrap() {
     }
 
     if (!accessToken) {
+      const e2eAccessToken = getCookieValue(E2E_ACCESS_TOKEN_COOKIE)
+      const e2eAccessTokenExpiresAtValue = getCookieValue(E2E_ACCESS_TOKEN_EXPIRES_AT_COOKIE)
+      const e2eAccessTokenExpiresAtMs = Number(e2eAccessTokenExpiresAtValue)
+
+      if (e2eAccessToken) {
+        setAccessToken(
+          e2eAccessToken,
+          Number.isFinite(e2eAccessTokenExpiresAtMs) ? e2eAccessTokenExpiresAtMs : 0,
+        )
+        return () => {
+          if (refreshTimer) clearTimeout(refreshTimer)
+        }
+      }
+
       void run()
       return () => {
         if (refreshTimer) clearTimeout(refreshTimer)

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import { request } from '@playwright/test'
+
+const DEFAULT_E2E_BASE_URL = 'http://localhost:3000'
+const E2E_LOGIN_PATH = '/api/e2e/login'
+const STORAGE_STATE_PATH = 'playwright/.auth/e2e-user.json'
+
+export default async function globalSetup() {
+  const baseURL = process.env.E2E_BASE_URL ?? DEFAULT_E2E_BASE_URL
+  const requestContext = await request.newContext({ baseURL })
+
+  const response = await requestContext.post(E2E_LOGIN_PATH, {
+    data: { deviceUuid: randomUUID() },
+  })
+
+  if (!response.ok()) {
+    const responseBody = await response.text()
+    throw new Error(
+      `E2E login failed during global setup: ${response.status()} ${response.statusText()} ${responseBody}`,
+    )
+  }
+
+  await mkdir(dirname(STORAGE_STATE_PATH), { recursive: true })
+  await requestContext.storageState({ path: STORAGE_STATE_PATH })
+  await requestContext.dispose()
+}

--- a/tests/e2e/protected.main.spec.ts
+++ b/tests/e2e/protected.main.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test'
 
-import { loginByE2EApi } from '../helpers/auth'
-
-test('보호 라우트 /main 접근', async ({ page, baseURL }) => {
-  if (!baseURL) throw new Error('baseURL is not set in Playwright config')
-
-  await loginByE2EApi({ page, baseURL })
-
+test('보호 라우트 /main 접근 시 프로필 대시보드가 보인다', async ({ page }) => {
   await page.goto('/main', { waitUntil: 'load' })
   await expect(page).toHaveURL(/\/main/)
+  await expect(page.getByAltText('profile image')).toBeVisible()
+  await expect(page.getByText('카드 수', { exact: true })).toBeVisible()
+  await expect(page.getByText('승리', { exact: true })).toBeVisible()
+  await expect(page.getByText('레벨', { exact: true })).toBeVisible()
+
+  await expect(page.getByText('레벨업 모드', { exact: true })).toBeVisible()
+  await expect(page.getByText('PVP 모드', { exact: true })).toBeVisible()
+
+  await expect(page.getByText('최근 학습', { exact: true })).toBeVisible()
+  await expect(page.getByText('최근 대결', { exact: true })).toBeVisible()
 })

--- a/tests/e2e/protected.mypage.spec.ts
+++ b/tests/e2e/protected.mypage.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+
+test('보호 라우트 /mypage 접근 시 프로필 대시보드 및 카드 목록이 보인다.', async ({ page }) => {
+  await page.goto('/mypage', { waitUntil: 'load' })
+  await expect(page).toHaveURL(/\/mypage/)
+  await expect(page.getByAltText('profile image', { exact: true })).toBeVisible()
+  await expect(page.getByText('카드 수', { exact: true })).toBeVisible()
+  await expect(page.getByText('승리', { exact: true })).toBeVisible()
+  await expect(page.getByText('레벨', { exact: true })).toBeVisible()
+
+  await expect(page.getByText('학습 목록')).toBeVisible()
+  await expect(page.getByText('대결 목록')).toBeVisible()
+})

--- a/tests/e2e/protected.pvppage.spec.ts
+++ b/tests/e2e/protected.pvppage.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+test('pvp 페이지 접근 시 매칭 입장/만들기 버튼이 보인다.', async ({ page }) => {
+  await page.goto('/pvp', { waitUntil: 'load' })
+  await expect(page).toHaveURL(/\/pvp/)
+
+  await expect(page.getByText('매칭 입장하기', { exact: true })).toBeVisible()
+  await expect(page.getByText('매칭 만들기', { exact: true })).toBeVisible()
+
+  await expect(page.getByText('최근 대결', { exact: true })).toBeVisible()
+})

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
 
+test.use({ storageState: { cookies: [], origins: [] } })
+
 test('홈 접근', async ({ page }) => {
   await page.goto('/')
   await expect(page).toHaveURL('/login')


### PR DESCRIPTION
## 개요

* PvP 페이지 진입을 포함한 **protected 영역 기본 e2e 시나리오**를 추가
* 테스트 실행 안정화를 위해 **global setup 기반 로그인 1회 수행 + storageState 재사용** 구조로 정리했고, e2e 환경에서는 **인증/refresh 흐름을 쿠키 기반으로 우회*
* e2e 실행 시 발생하던 잡음(빈 body metrics 요청, 잘못된 next experimental 키, eslint ignore)을 정리

---

## 변경사항

### 1) e2e 기본 시나리오 추가

* `tests/e2e/protected.main.spec.ts`
  * `/main` 진입 시 프로필 대시보드 검증
* `tests/e2e/protected.mypage.spec.ts`
  * `/mypage` 진입 시 프로필 대시보드 + 목록 검증
* `tests/e2e/protected.pvppage.spec.ts`
  * `/pvp` 진입 시 매칭 입장/만들기 버튼 + 최근 대결 영역 검증
* `tests/e2e/smoke.spec.ts`
  * 비로그인 홈 접근 검증 유지

### 2) e2e 로그인 구조 안정화

* `tests/e2e/global-setup.ts` 추가
  * 테스트 시작 전에 `/api/e2e/login`을 1회 호출
  * 쿠키를 `storageState`로 저장
* `playwright.e2e.config.ts`
  * `globalSetup` 연결
  * `storageState` 재사용
  * `workers: 1`로 직렬 실행
  * `pnpm dev` + `localhost:3000` 기준으로 실행되도록 정리(3001 제거)

### 3) e2e 전용 인증 우회 추가

* `src/app/(public)/api/e2e/login/route.ts`
  * `refresh_token` 외에 아래 쿠키도 저장:
    * `e2e_access_token`
    * `e2e_access_token_expires_at`
* `src/features/provider/ui/AuthBootStrap.tsx`
  * access token이 없을 때 e2e 쿠키를 먼저 읽어 store 초기화
* `src/app/(public)/api/auth/refresh/route.ts`
  * e2e 환경이면 `refresh_token` 대신 `e2e_access_token` 기반으로 refresh 응답 우회

### 4) e2e 관련 잡음 제거

* `src/app/api/metrics/route.ts`
  * 빈 body 요청 방어 처리 추가
* `next.config.mjs`
  * invalid experimental key `trustHostHeader` 제거
* `eslint.config.mjs`
  * `.next-3001` ignore 추가

---

## Screenshots (UI 변경 시)

* (해당 없음) 
---

## How to test

1. 설치/실행

* `pnpm i`
* `pnpm dev` (localhost:3000 기준)

2. 정적 검증

* `pnpm lint`
* `pnpm build`

3. e2e 실행

* 프로젝트에서 사용하는 e2e 실행 커맨드로 실행(예: `pnpm test:e2e` 또는 `pnpm playwright test -c playwright.e2e.config.ts`)
* 확인 포인트:
  * global setup이 `/api/e2e/login`을 1회 호출하고 `storageState`를 생성/재사용하는지
  * `/main`, `/mypage`, `/pvp` spec이 정상 통과하는지
  * 비로그인 `smoke`는 로그인 상태 격리 후 통과하는지(현재는 재확인 단계)

---

## 참고 커밋

* `ec9dedf` test: e2e load pvp page
