### PR TITLE
Refactor/levelup recording rendering

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
+++ b/src/_pages/pvp/matching/ui/PvPMatchingPage.tsx
@@ -121,7 +121,7 @@ export function PvPMatchingPage() {
     isRecording,
     // 일시정지 여부(현재 PvP는 pause 비활성 설계지만 UI 호환으로 유지)
     isPaused,
-    elapsedSeconds,
+    getElapsedSeconds,
     recordedBlob,
     // 마이크 상호작용 허용 여부
     isMicInteractionAllowed,
@@ -224,7 +224,7 @@ export function PvPMatchingPage() {
           isProcessingStep={isProcessingStep}
           isRecording={isRecording}
           isPaused={isPaused}
-          elapsedSeconds={elapsedSeconds}
+          getElapsedSeconds={getElapsedSeconds}
           isMicDisabled={Boolean(recordedBlob) || !isMicInteractionAllowed}
           onMicClick={() => {
             void handlePvPMicClick()

--- a/src/_pages/record/ui/LevelUpRecordPage.tsx
+++ b/src/_pages/record/ui/LevelUpRecordPage.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
+import { memo } from 'react'
 
+import { useCardDetails } from '@/features/levelup-feedback'
 import { MicrophoneBox, useLevelUpRecordController } from '@/features/record'
 import { AlertModal, Button, ModeHeader, RecordTipBox, StatusLoader, SubjectHeader } from '@/shared'
 
@@ -10,6 +12,11 @@ import { useLevelUpRecordExitGuard } from '../model/useLevelUpRecordExitGuard'
 const RECORD_PROGRESS_VALUE = 100
 const RECORD_STEP_LABEL = '3/3'
 
+type RecordSubmitButtonProps = {
+  onComplete: () => Promise<void>
+  isSubmitting: boolean
+}
+
 function parseOptionalNumber(value: string | null): number | undefined {
   if (!value) return undefined
 
@@ -17,14 +24,31 @@ function parseOptionalNumber(value: string | null): number | undefined {
   return Number.isNaN(parsedValue) ? undefined : parsedValue
 }
 
+const RecordSubmitButton = memo(function RecordSubmitButton({
+  onComplete,
+  isSubmitting,
+}: RecordSubmitButtonProps) {
+  return (
+    <div className="mt-auto mb-6 flex w-full items-center justify-center gap-4 pt-4">
+      <Button
+        variant="record_confirm_btn"
+        onClick={onComplete}
+        disabled={isSubmitting}
+      >
+        녹음 완료 및 피드백 받기
+      </Button>
+    </div>
+  )
+})
+
 export function LevelUpRecordPage() {
   const searchParams = useSearchParams()
   const cardId = parseOptionalNumber(searchParams.get('cardId'))
   const attemptId = parseOptionalNumber(searchParams.get('attemptId'))
   const attemptNo = parseOptionalNumber(searchParams.get('attemptNo'))
+  const { data } = useCardDetails(cardId)
 
   const {
-    data,
     isSubmittingFeedback,
     uploadStatus,
     isStartingWarmup,
@@ -32,7 +56,7 @@ export function LevelUpRecordPage() {
     isMicAlertOpen,
     isRecording,
     isPaused,
-    elapsedSeconds,
+    getElapsedSeconds,
     recordedBlob,
     handleMicClick,
     handleMicAlertOpenChange,
@@ -72,19 +96,14 @@ export function LevelUpRecordPage() {
           isMicDisabled={Boolean(recordedBlob)}
           isRecording={isRecording}
           isPaused={isPaused}
-          elapsedSeconds={elapsedSeconds}
+          getElapsedSeconds={getElapsedSeconds}
         />
       )}
       <RecordTipBox />
-      <div className="mt-auto mb-6 flex w-full items-center justify-center gap-4 pt-4">
-        <Button
-          variant="record_confirm_btn"
-          onClick={handleRecordingComplete}
-          disabled={isSubmittingFeedback}
-        >
-          녹음 완료 및 피드백 받기
-        </Button>
-      </div>
+      <RecordSubmitButton
+        onComplete={handleRecordingComplete}
+        isSubmitting={isSubmittingFeedback}
+      />
       <AlertModal
         open={isBackAlertOpen}
         onOpenChange={handleBackAlertOpenChange}

--- a/src/features/pvp/model/usePvPRecordController.ts
+++ b/src/features/pvp/model/usePvPRecordController.ts
@@ -47,7 +47,7 @@ type UsePvPRecordControllerParams = {
 type UsePvPRecordControllerResult = {
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number
+  getElapsedSeconds: () => number
   recordedBlob: Blob | null
   // 현재 마이크 클릭 허용 여부
   isMicInteractionAllowed: boolean
@@ -80,7 +80,7 @@ export function usePvPRecordController({
     stopRecordingAndGetBlob,
     isRecording,
     isPaused,
-    elapsedSeconds,
+    getElapsedSeconds,
     recordedBlob,
     autoStopped,
     resetAutoStopped,
@@ -236,11 +236,11 @@ export function usePvPRecordController({
   return {
     isRecording,
     isPaused,
-    elapsedSeconds,
     recordedBlob,
     isMicInteractionAllowed,
     isSubmittingSubmission,
     isSubmissionCompleted,
+    getElapsedSeconds,
     // 소켓 self ANSWER_SUBMITTED 수신 시 로컬 완료 상태를 동기화한다.
     markSubmissionCompleted: () => {
       setIsSubmissionCompleted(true)

--- a/src/features/pvp/ui/PvPBattleSection.tsx
+++ b/src/features/pvp/ui/PvPBattleSection.tsx
@@ -19,7 +19,7 @@ type PvPBattleSectionProps = {
   // 녹음 컨트롤러 상태
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number
+  getElapsedSeconds: () => number
   isMicDisabled: boolean
   // 마이크/준비 버튼 액션
   onMicClick: () => void
@@ -36,7 +36,7 @@ export function PvPBattleSection({
   isProcessingStep,
   isRecording,
   isPaused,
-  elapsedSeconds,
+  getElapsedSeconds,
   isMicDisabled,
   onMicClick,
   onReadyClick,
@@ -63,7 +63,7 @@ export function PvPBattleSection({
           isMicDisabled={isMicDisabled}
           isRecording={isRecording}
           isPaused={isPaused}
-          elapsedSeconds={elapsedSeconds}
+          getElapsedSeconds={getElapsedSeconds}
         />
       )}
       {/* 녹음 가이드와 준비 버튼은 battle 영역 하단에 고정한다. */}

--- a/src/features/record/model/useLevelUpRecordController.ts
+++ b/src/features/record/model/useLevelUpRecordController.ts
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { startWarmup } from '@/features/levelup'
-import { useCardDetails } from '@/features/levelup-feedback'
 import { resolveAudioContentType } from '@/shared'
 
 import { completeAudioUpload } from '../api/completeAudioUpload'
@@ -26,7 +25,6 @@ type UseLevelUpRecordControllerParams = {
 }
 
 type UseLevelUpRecordControllerResult = {
-  data: ReturnType<typeof useCardDetails>['data']
   isSubmittingFeedback: boolean
   uploadStatus: FeedbackStatus | null
   isStartingWarmup: boolean
@@ -34,10 +32,10 @@ type UseLevelUpRecordControllerResult = {
   isMicAlertOpen: boolean
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number
   recordedBlob: Blob | null
   handleMicClick: () => Promise<void>
   handleMicAlertOpenChange: (open: boolean) => void
+  getElapsedSeconds: () => number
   handleRecordingComplete: () => Promise<void>
 }
 
@@ -47,13 +45,12 @@ export function useLevelUpRecordController({
   attemptNo,
 }: UseLevelUpRecordControllerParams): UseLevelUpRecordControllerResult {
   const router = useRouter()
-  const { data } = useCardDetails(cardId)
 
   const {
     isMicAlertOpen,
     isRecording,
     isPaused,
-    elapsedSeconds,
+    getElapsedSeconds,
     recordedBlob,
     autoStopped,
     handleMicClick: handleBaseMicClick,
@@ -190,7 +187,6 @@ export function useLevelUpRecordController({
   }, [autoStopped, handleRecordingComplete, isSubmittingFeedback, recordedBlob, resetAutoStopped])
 
   return {
-    data,
     isSubmittingFeedback,
     uploadStatus,
     isStartingWarmup,
@@ -198,10 +194,10 @@ export function useLevelUpRecordController({
     isMicAlertOpen,
     isRecording,
     isPaused,
-    elapsedSeconds,
     recordedBlob,
     handleMicClick,
     handleMicAlertOpenChange,
+    getElapsedSeconds,
     handleRecordingComplete,
   }
 }

--- a/src/features/record/model/useRecordController.ts
+++ b/src/features/record/model/useRecordController.ts
@@ -11,12 +11,12 @@ export type UseRecordControllerResult = {
   isMicAlertOpen: boolean
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number
   recordedBlob: Blob | null
   autoStopped: boolean
   handleMicClick: () => Promise<void>
   handleMicAlertOpenChange: (open: boolean) => void
   stopRecordingAndGetBlob: () => Promise<Blob | null>
+  getElapsedSeconds: () => number
   getDurationSeconds: () => number
   clearRecordedBlob: () => void
   resetAutoStopped: () => void
@@ -39,7 +39,7 @@ export function useRecordController({
     isPaused,
     pauseRecording,
     resumeRecording,
-    elapsedSeconds,
+    getElapsedSeconds,
     getDurationSeconds,
     clearRecordedBlob,
     autoStopped,
@@ -74,12 +74,12 @@ export function useRecordController({
     isMicAlertOpen,
     isRecording,
     isPaused,
-    elapsedSeconds,
     recordedBlob,
     autoStopped,
     handleMicClick,
     handleMicAlertOpenChange,
     stopRecordingAndGetBlob,
+    getElapsedSeconds,
     getDurationSeconds,
     clearRecordedBlob,
     resetAutoStopped,

--- a/src/features/record/ui/MicrophoneBox.tsx
+++ b/src/features/record/ui/MicrophoneBox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { CircleStop, Mic } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 type MicrophoneBoxProps = {
   isStartingWarmup?: boolean
@@ -12,7 +13,7 @@ type MicrophoneBoxProps = {
   isMicDisabled: boolean
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number
+  getElapsedSeconds: () => number
 }
 
 const WRAPPER_CLASSNAME = 'mt-4 flex w-full flex-col items-center'
@@ -25,6 +26,7 @@ const RECORDING_LABEL_CLASSNAME = 'text-sm text-red-500'
 const PAUSED_LABEL_CLASSNAME = 'text-sm text-red-500'
 const SECONDS_PER_MINUTE = 60
 const TIME_PAD_LENGTH = 2
+const ELAPSED_TIME_TICK_MS = 500
 
 const formatElapsedTime = (totalSeconds: number) => {
   const minutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE)
@@ -42,10 +44,27 @@ export function MicrophoneBox({
   isMicDisabled,
   isRecording,
   isPaused,
-  elapsedSeconds,
+  getElapsedSeconds,
 }: MicrophoneBoxProps) {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const displayedElapsedSeconds = isRecording ? elapsedSeconds : 0
+
+  useEffect(() => {
+    if (!isRecording || isPaused) {
+      return
+    }
+
+    const timerId = window.setInterval(() => {
+      setElapsedSeconds(getElapsedSeconds())
+    }, ELAPSED_TIME_TICK_MS)
+
+    return () => {
+      window.clearInterval(timerId)
+    }
+  }, [getElapsedSeconds, isPaused, isRecording])
+
   const micIconClassName = isMicDisabled ? MIC_ICON_DISABLED_CLASSNAME : MIC_ICON_ACTIVE_CLASSNAME
-  const recordingLabel = `녹음 중... ${formatElapsedTime(elapsedSeconds)}`
+  const recordingLabel = `녹음 중... ${formatElapsedTime(displayedElapsedSeconds)}`
 
   return (
     <div className={WRAPPER_CLASSNAME}>

--- a/src/shared/lib/useMicrophone.ts
+++ b/src/shared/lib/useMicrophone.ts
@@ -16,7 +16,6 @@ const DEFAULT_MIC_PERMISSION_STATE = 'unavailable'
 type UseMicrophoneResult = {
   isRecording: boolean
   isPaused: boolean
-  elapsedSeconds: number // 현재 녹음 경과(초) - UI 타이머 표시용
   recordedDurationSeconds: number // 최종 녹음 길이(초) - stop 시점에 확정
   micPermissionState: string // 권한 상태 문자열(permissions API 기반)
   isMicAlertOpen: boolean // 마이크 권한 안내 모달 open 상태
@@ -26,6 +25,7 @@ type UseMicrophoneResult = {
   recordedBlob: Blob | null // 녹음 완료 후 생성된 Blob
   startRecording: () => Promise<boolean> // 녹음 시작 (권한 확인 포함)
   stopRecordingAndGetBlob: () => Promise<Blob | null> // stop 후 blob 반환(비동기)
+  getElapsedSeconds: () => number // 현재 녹음 경과(초) - UI 표시용 getter
   getDurationSeconds: () => number // duration 계산(확정값 or 경과값)
   pauseRecording: () => void // 일시정지
   resumeRecording: () => void // 재개
@@ -38,11 +38,10 @@ export function useMicrophone(): UseMicrophoneResult {
   const [isRecording, setIsRecording] = useState(false)
   const [isPaused, setIsPaused] = useState(false)
 
-  // ✅ UI에 표시할 타이머(초)
-  const [elapsedSeconds, setElapsedSeconds] = useState(0)
-
   // ✅ 최종 녹음 길이(초) - stop 시점에 set
   const [recordedDurationSeconds, setRecordedDurationSeconds] = useState(0)
+  // ✅ stop 직후에도 동기적으로 duration을 읽을 수 있도록 최종 duration을 ref에도 저장한다.
+  const recordedDurationSecondsRef = useRef(0)
 
   // ✅ permissions API로 얻은 마이크 권한 상태
   const [micPermissionState, setMicPermissionState] = useState<string>(DEFAULT_MIC_PERMISSION_STATE)
@@ -55,17 +54,19 @@ export function useMicrophone(): UseMicrophoneResult {
 
   // ✅ 녹음 결과 Blob
   const [recordedBlob, setRecordedBlob] = useState<Blob | null>(null)
+  const recordedBlobRef = useRef<Blob | null>(null)
 
   // ✅ 실제 MediaRecorder 인스턴스(녹음 수행 엔진)
   const [recorder, setRecorder] = useState<MediaRecorder | null>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
 
   // ✅ getUserMedia로 얻은 stream (stop 시 track stop 필요)
-  const [recordingStream, setRecordingStream] = useState<MediaStream | null>(null)
+  const recordingStreamRef = useRef<MediaStream | null>(null)
 
   // ✅ “최대 녹음 제한” 타이머 id 저장
   const recordTimeoutRef = useRef<number | null>(null)
 
-  // ✅ elapsedSeconds를 업데이트하는 interval id 저장
+  // ✅ 경과 시간 계산 tick interval id 저장
   const elapsedIntervalRef = useRef<number | null>(null)
 
   // ✅ MediaRecorder에서 오는 chunk들을 모아두는 버퍼(BlobPart[])
@@ -84,56 +85,57 @@ export function useMicrophone(): UseMicrophoneResult {
   const stopResolveRef = useRef<((blob: Blob | null) => void) | null>(null)
 
   // ✅ 녹음 정지 함수(내부용). isAutoStop=true면 자동 종료 플래그를 세팅
-  const stopRecording = useCallback(
-    (isAutoStop = false) => {
-      // ✅ “녹음 중”이었다면, 마지막 구간의 elapsedMs를 누적
-      if (recordStartAtRef.current) {
-        const elapsedMs = Date.now() - recordStartAtRef.current
-        elapsedMsRef.current += elapsedMs
+  const stopRecording = useCallback((isAutoStop = false) => {
+    // ✅ “녹음 중”이었다면, 마지막 구간의 elapsedMs를 누적
+    if (recordStartAtRef.current) {
+      const elapsedMs = Date.now() - recordStartAtRef.current
+      elapsedMsRef.current += elapsedMs
+    }
+
+    // ✅ 최종 duration(초) 확정 값 세팅(0 미만 방지)
+    const finalizedDurationSeconds = Math.floor(Math.max(0, elapsedMsRef.current) / 1000)
+    recordedDurationSecondsRef.current = finalizedDurationSeconds
+    setRecordedDurationSeconds(finalizedDurationSeconds)
+
+    // ✅ autoStop 여부 반영
+    setAutoStopped(isAutoStop)
+
+    // ✅ 최대 제한 timeout 정리
+    if (recordTimeoutRef.current) {
+      window.clearTimeout(recordTimeoutRef.current)
+      recordTimeoutRef.current = null
+    }
+
+    // ✅ recorder가 활성 상태면 stop 호출
+    const currentRecorder = recorderRef.current
+    if (currentRecorder && currentRecorder.state !== 'inactive') {
+      try {
+        currentRecorder.stop() // ✅ 여기서 onstop 이벤트가 발생하며 Blob 생성 로직이 실행됨
+      } catch {
+        // ignore: recorder.stop 예외는 무시(브라우저/상태 경쟁)
       }
+    }
 
-      // ✅ 최종 duration(초) 확정 값 세팅(0 미만 방지)
-      setRecordedDurationSeconds(Math.floor(Math.max(0, elapsedMsRef.current) / 1000))
+    // ✅ stream 트랙 종료(마이크 리소스 반환)
+    const currentRecordingStream = recordingStreamRef.current
+    if (currentRecordingStream) {
+      currentRecordingStream.getTracks().forEach((track) => track.stop())
+    }
 
-      // ✅ autoStop 여부 반영
-      setAutoStopped(isAutoStop)
+    // ✅ 내부 상태 리셋
+    setRecorder(null)
+    recorderRef.current = null
+    recordingStreamRef.current = null
+    setIsRecording(false)
+    setIsPaused(false)
 
-      // ✅ 최대 제한 timeout 정리
-      if (recordTimeoutRef.current) {
-        window.clearTimeout(recordTimeoutRef.current)
-        recordTimeoutRef.current = null
-      }
+    // ✅ 타이머 ref 초기화
+    recordStartAtRef.current = null
+    elapsedMsRef.current = 0
+    remainingMsRef.current = MAX_RECORDING_MS
+  }, [])
 
-      // ✅ recorder가 활성 상태면 stop 호출
-      if (recorder && recorder.state !== 'inactive') {
-        try {
-          recorder.stop() // ✅ 여기서 onstop 이벤트가 발생하며 Blob 생성 로직이 실행됨
-        } catch {
-          // ignore: recorder.stop 예외는 무시(브라우저/상태 경쟁)
-        }
-      }
-
-      // ✅ stream 트랙 종료(마이크 리소스 반환)
-      if (recordingStream) {
-        recordingStream.getTracks().forEach((track) => track.stop())
-      }
-
-      // ✅ 내부 상태 리셋
-      setRecorder(null)
-      setRecordingStream(null)
-      setIsRecording(false)
-      setIsPaused(false)
-
-      // ✅ 타이머 ref/상태 초기화
-      recordStartAtRef.current = null
-      elapsedMsRef.current = 0
-      remainingMsRef.current = MAX_RECORDING_MS
-      setElapsedSeconds(0)
-    },
-    [recorder, recordingStream], // ⚠️ state 의존으로 stopRecording 참조가 변할 수 있음(정리 포인트에서 개선 제안)
-  )
-
-  // ✅ 녹음 중 + 일시정지 아님 상태에서 elapsedSeconds 업데이트
+  // ✅ 녹음 중 + 일시정지 아님 상태에서 자동 종료 시점만 감시한다.
   useEffect(() => {
     if (!isRecording || isPaused) return
 
@@ -144,11 +146,7 @@ export function useMicrophone(): UseMicrophoneResult {
       // ✅ 최대 시간 초과면 자동 종료 처리
       if (elapsedMs >= MAX_RECORDING_MS) {
         stopRecording(true)
-        return
       }
-
-      // ✅ UI 표시용 경과초 업데이트
-      setElapsedSeconds(Math.floor(Math.max(0, elapsedMs) / 1000))
     }, TIMER_INTERVAL_MS)
 
     // ✅ cleanup: interval 제거
@@ -166,11 +164,13 @@ export function useMicrophone(): UseMicrophoneResult {
       if (recordTimeoutRef.current) {
         window.clearTimeout(recordTimeoutRef.current)
       }
-      if (recordingStream) {
-        recordingStream.getTracks().forEach((track) => track.stop())
+
+      const currentRecordingStream = recordingStreamRef.current
+      if (currentRecordingStream) {
+        currentRecordingStream.getTracks().forEach((track) => track.stop())
       }
     }
-  }, [recordingStream])
+  }, [])
 
   // ✅ permissions API로 마이크 권한 상태 확인(지원 안 하면 unavailable)
   const checkPermission = async () => {
@@ -241,7 +241,9 @@ export function useMicrophone(): UseMicrophoneResult {
     // 5) chunk 버퍼/상태 초기화
     chunksRef.current = []
     setRecordedBlob(null)
+    recordedBlobRef.current = null
     setRecordedDurationSeconds(0)
+    recordedDurationSecondsRef.current = 0
 
     // 6) 데이터 chunk 수집 핸들러
     startResult.recorder.ondataavailable = (event) => {
@@ -260,6 +262,7 @@ export function useMicrophone(): UseMicrophoneResult {
       if (blob) {
         setRecordedBlob(blob)
       }
+      recordedBlobRef.current = blob
 
       // ✅ 버퍼 비움
       chunksRef.current = []
@@ -274,7 +277,8 @@ export function useMicrophone(): UseMicrophoneResult {
 
     // 8) recorder/stream 상태 저장
     setRecorder(startResult.recorder)
-    setRecordingStream(startResult.stream)
+    recorderRef.current = startResult.recorder
+    recordingStreamRef.current = startResult.stream
 
     // 9) UI 상태 초기화 및 시작 시각 기록
     setIsRecording(true)
@@ -285,7 +289,6 @@ export function useMicrophone(): UseMicrophoneResult {
     recordStartAtRef.current = Date.now()
     elapsedMsRef.current = 0
     remainingMsRef.current = MAX_RECORDING_MS
-    setElapsedSeconds(0)
 
     // 10) 최대 녹음 제한 timeout 설정
     recordTimeoutRef.current = window.setTimeout(() => {
@@ -336,15 +339,17 @@ export function useMicrophone(): UseMicrophoneResult {
   }
 
   // ✅ recordedBlob 초기화(UI에서 “다시 녹음” 같은 흐름에 사용)
-  const clearRecordedBlob = () => {
+  const clearRecordedBlob = useCallback(() => {
     setRecordedBlob(null)
-  }
+    recordedBlobRef.current = null
+  }, [])
 
   // ✅ stop 후 Blob을 “반환” 받고 싶을 때 사용(비동기)
-  const stopRecordingAndGetBlob = async () => {
+  const stopRecordingAndGetBlob = useCallback(async () => {
     // ✅ recorder가 없거나 inactive면 이미 stop 상태 → 현재 recordedBlob 반환
-    if (!recorder || recorder.state === 'inactive') {
-      return recordedBlob
+    const currentRecorder = recorderRef.current
+    if (!currentRecorder || currentRecorder.state === 'inactive') {
+      return recordedBlobRef.current
     }
 
     // ✅ recorder.stop()은 onstop 이벤트가 async로 오므로 Promise로 감싼다
@@ -352,20 +357,39 @@ export function useMicrophone(): UseMicrophoneResult {
       stopResolveRef.current = resolve // onstop에서 resolve 호출
       stopRecording(false) // 실제 stop 수행
     })
-  }
+  }, [stopRecording])
 
-  // ✅ duration 계산: stop 시 recordedDurationSeconds가 있으면 그걸 사용, 없으면 elapsedSeconds
-  const getDurationSeconds = () =>
-    recordedDurationSeconds > 0 ? recordedDurationSeconds : elapsedSeconds
+  // ✅ 현재 경과 초 계산: 녹음 중이면 ref 기반으로 계산하고, stop 이후엔 확정 duration을 사용한다.
+  const getElapsedSeconds = useCallback(() => {
+    if (recordedDurationSecondsRef.current > 0) {
+      return recordedDurationSecondsRef.current
+    }
+
+    if (!isRecording || !recordStartAtRef.current) {
+      return Math.floor(Math.max(0, elapsedMsRef.current) / 1000)
+    }
+
+    const elapsedMs = elapsedMsRef.current + (Date.now() - recordStartAtRef.current)
+    return Math.floor(Math.max(0, elapsedMs) / 1000)
+  }, [isRecording])
+
+  const getDurationSeconds = useCallback(
+    () =>
+      recordedDurationSecondsRef.current > 0
+        ? recordedDurationSecondsRef.current
+        : getElapsedSeconds(),
+    [getElapsedSeconds],
+  )
 
   // ✅ autoStopped 플래그 초기화(컨트롤러에서 소비 후 reset)
-  const resetAutoStopped = () => setAutoStopped(false)
+  const resetAutoStopped = useCallback(() => {
+    setAutoStopped(false)
+  }, [])
 
   // ✅ 외부로 공개
   return {
     isRecording,
     isPaused,
-    elapsedSeconds,
     recordedDurationSeconds,
     micPermissionState,
     isMicAlertOpen,
@@ -375,6 +399,7 @@ export function useMicrophone(): UseMicrophoneResult {
     recordedBlob,
     startRecording,
     stopRecordingAndGetBlob,
+    getElapsedSeconds,
     getDurationSeconds,
     pauseRecording,
     resumeRecording,


### PR DESCRIPTION
#129 
## 개요
* `LevelUpRecordPage`의 녹음 플로우에서 불필요한 리렌더/콜백 흔들림을 줄여 **렌더링 안정성**을 개선
* `useMicrophone` 내부 로직을 `ref + useCallback` 기반으로 정리해, `recorder/stream` state 변화에 따라 `stopRecording` 동작이 흔들리거나 후속 처리(Blob/duration)가 꼬이는 문제를 완화
* MVP2 2차 QA 수정사항 반영: PvP 매칭에서 나가기(Exit) 시 라우팅이 어색하게 동작하던 부분을 `usePvPMatchingExitGuard`에서 수정.

---

## 변경사항
### 1) 레벨업 녹음 렌더링 최적화
* 파일: `src/_pages/record/ui/LevelUpRecordPage.tsx`
* 내용:
  * 녹음 완료 버튼을 `memo` 컴포넌트로 분리하여 불필요한 리렌더 감소

### 2) 마이크 훅 콜백 안정화 (`useMicrophone`)
* 파일: `src/shared/lib/useMicrophone.ts`
* 내용:
  * `clearRecordedBlob`, `stopRecordingAndGetBlob`, `resetAutoStopped`를 `useCallback` 처리
  * `stopRecording`이 `recorder/stream` state 변화에 흔들리지 않도록 **ref 기반**으로 정리
  * `recordedBlobRef`, `recorderRef`, `recordingStreamRef` 도입으로 참조 안정성 강화
* 효과:
  * 녹음 종료/중지 시점에 따라 후속 처리(Blob 반환, auto-stop 상태 등)가 불안정하던 가능성 감소

### 3) duration 계산 안정화
* 파일: `src/shared/lib/useMicrophone.ts` (및 사용처 연동부)
* 내용:
  * 녹음 종료 직후 `durationSeconds`가 0으로 내려가는 타이밍 이슈를 ref 기반으로 보완
  * 완료 처리 시점에 동기적으로 최종 duration을 읽도록 정리

### 4) LevelUp/PvP 녹음 흐름 연동부 정리
* 대상 파일:
  * `src/features/record/model/useLevelUpRecordController.ts`
  * `src/features/record/model/useRecordController.ts`
  * `src/features/record/ui/MicrophoneBox.tsx`
  * `src/features/pvp/model/usePvPRecordController.ts`
  * `src/features/pvp/ui/PvPBattleSection.tsx`
  * `src/_pages/pvp/matching/ui/PvPMatchingPage.tsx`
* 내용:
  * ref/콜백 안정화 변경에 맞춰 함수 참조 및 호출 흐름을 조정

### 5) PvP 나가기 라우팅 수정
* 파일: `src/features/pvp/model/usePvPMatchingExitGuard.ts`
* 내용:
  * Exit 시 라우팅 관련 경미한 보정 (`fix: pvp exit route`)

---

## Screenshots (UI 변경 시)

* LevelUp 녹음 페이지에서 녹음/완료 버튼 렌더 흐름 before/after
before

https://github.com/user-attachments/assets/51871c14-cc23-4489-8a2d-9290d2f070c6

after

https://github.com/user-attachments/assets/9471cdd1-617c-41de-9d66-4c6f3490eee3



---

## How to test

1. 설치/실행

* `pnpm i`
* `pnpm dev`

2. LevelUp 녹음 플로우 확인

* `LevelUpRecordPage` 진입
* 녹음 시작 → 중지/완료 → 재시도 등 시나리오 반복
* 아래 확인:
  * 완료 버튼/하단 UI가 불필요하게 깜빡이거나 과도하게 리렌더되지 않는지
  * `stopRecordingAndGetBlob`이 안정적으로 Blob을 반환하는지
  * auto-stop 후 상태 초기화(`resetAutoStopped`)가 정상인지
  * 녹음 종료 직후 `durationSeconds`가 0으로 떨어지는 현상이 재발하지 않는지(결과/업로드/제출 단계에서 duration이 정상인지)

3. PvP 녹음/매칭 연동 회귀 확인
* PvP 매칭 진입 → 녹음 시작/종료 흐름(가능한 범위) 확인
* `usePvPRecordController` 연동부에서 예외/중복 호출이 없는지 확인

4. PvP 나가기 라우팅 확인
* 매칭 페이지에서 Exit 시 의도된 경로(/pvp)로 이동하는지 확인

---

## 참고 커밋

* `c3089b6` refactor: stabilize record flow renders and callbacks
* `fb4680c` fix: pvp exit route

