### PR TITLE
fix: handle sse status-update and completed feedback rendering

### DIFF
--- a/src/features/levelup-feedback/api/getAttemptStream.ts
+++ b/src/features/levelup-feedback/api/getAttemptStream.ts
@@ -24,6 +24,7 @@ export type GetAttemptStreamResult =
 
 const INVALID_PARAMS_REASON = 'invalid_params'
 const PARSE_FAILED_REASON = 'parse_failed'
+const SSE_STATUS_UPDATE_EVENT_NAME = 'status-update'
 
 const isFeedbackStatus = (value: unknown): value is FeedbackStatus =>
   value === 'PENDING' ||
@@ -78,7 +79,7 @@ export function getAttemptStream(
   // EventSource는 브라우저 표준 SSE 클라이언트
   const eventSource = new EventSource(createAttemptStreamUrl(params))
 
-  eventSource.onmessage = (event) => {
+  const handleSseMessage = (event: MessageEvent<string>) => {
     try {
       const parsedPayload = parseAttemptStreamPayload(JSON.parse(event.data))
       if (!parsedPayload.ok) {
@@ -91,6 +92,10 @@ export function getAttemptStream(
       console.error('Failed to parse attempt stream event', error)
     }
   }
+
+  // 기본 message 이벤트와 커스텀 status-update 이벤트를 모두 수신한다.
+  eventSource.onmessage = handleSseMessage
+  eventSource.addEventListener(SSE_STATUS_UPDATE_EVENT_NAME, handleSseMessage)
 
   if (onError) {
     // 연결 끊김/네트워크 오류 처리 전략은 상위 훅(useFeedbackStream)에서 관리

--- a/src/features/levelup-feedback/model/useFeedbackStream.ts
+++ b/src/features/levelup-feedback/model/useFeedbackStream.ts
@@ -9,6 +9,8 @@ import { getAttemptStream } from '../api/getAttemptStream'
 import type { FeedbackItem, FeedbackProcessingStep, FeedbackStatus } from './feedbackTypes'
 
 const FEEDBACK_TIMEOUT_MS = 5 * 60 * 1000
+const COMPLETED_FEEDBACK_FETCH_RETRY_DELAY_MS = 1000
+const COMPLETED_FEEDBACK_FETCH_MAX_RETRIES = 5
 const DEFAULT_FEEDBACK_STATUS: FeedbackStatus = 'PROCESSING'
 const TERMINAL_FEEDBACK_STATUSES: FeedbackStatus[] = ['COMPLETED', 'FAILED', 'EXPIRED']
 
@@ -46,6 +48,11 @@ const mapFeedbackItem = (
   ]
 }
 
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
+
 export function useFeedbackStream({
   cardId,
   attemptId,
@@ -65,6 +72,7 @@ export function useFeedbackStream({
 
     let isCancelled = false
     let isClosedByClient = false
+    let hasReceivedTerminalEvent = false
     let timeoutId: number | null = null
     let eventSource: EventSource | null = null
 
@@ -83,13 +91,23 @@ export function useFeedbackStream({
     }
 
     const handleCompleted = async () => {
-      // COMPLETED 이벤트는 요약 신호이므로, 최종 상세 데이터는 1회 재조회한다.
-      const details = await getAttemptDetails(cardId, attemptId)
-      if (isCancelled || !details) return
+      // COMPLETED 직후 백엔드 저장 반영이 늦을 수 있어, 상세 피드백 조회를 짧게 재시도한다.
+      for (let retryCount = 0; retryCount < COMPLETED_FEEDBACK_FETCH_MAX_RETRIES; retryCount += 1) {
+        const details = await getAttemptDetails(cardId, attemptId)
+        if (isCancelled) return
 
-      setStatus('COMPLETED')
-      setProcessingStep(null)
-      setFeedbackData(mapFeedbackItem(details))
+        if (details?.feedback) {
+          setStatus('COMPLETED')
+          setProcessingStep(null)
+          setFeedbackData(mapFeedbackItem(details))
+          return
+        }
+
+        await delay(COMPLETED_FEEDBACK_FETCH_RETRY_DELAY_MS)
+      }
+
+      // COMPLETED 후에도 피드백 상세를 가져오지 못하면 실패 처리로 전환한다.
+      void onFailed?.()
     }
 
     const startStream = async () => {
@@ -113,35 +131,39 @@ export function useFeedbackStream({
           onMessage: (payload) => {
             if (isCancelled) return
 
-            // 서버 상태를 그대로 UI 상태로 반영한다.
-            setStatus(payload.status)
-            if (payload.status === 'PROCESSING' && payload.step) {
-              setProcessingStep(payload.step)
-            } else {
-              setProcessingStep(null)
-            }
-
             // 완료/실패/만료는 즉시 스트림을 닫고 후속 처리를 실행한다.
             if (payload.status === 'COMPLETED') {
+              hasReceivedTerminalEvent = true
               closeStream()
               void handleCompleted()
               return
             }
 
             if (payload.status === 'FAILED') {
+              hasReceivedTerminalEvent = true
               closeStream()
               void onFailed?.()
               return
             }
 
             if (payload.status === 'EXPIRED') {
+              hasReceivedTerminalEvent = true
               closeStream()
               void onTimeout?.()
               return
             }
+
+            // 종료 이벤트가 아니면 서버 상태를 그대로 UI 상태로 반영한다.
+            setStatus(payload.status)
+            if (payload.status === 'PROCESSING' && payload.step) {
+              setProcessingStep(payload.step)
+            } else {
+              setProcessingStep(null)
+            }
           },
           onError: () => {
-            if (isCancelled || isClosedByClient) return
+            // 서버가 종료 이벤트를 보낸 뒤 닫은 연결은 정상 흐름으로 본다.
+            if (isCancelled || isClosedByClient || hasReceivedTerminalEvent) return
             closeStream()
             void onFailed?.()
           },


### PR DESCRIPTION
## 개요
* LevelUp 피드백 SSE 수신에서 커스텀 이벤트(`event: status-update`)를 처리하지 못해 `PROCESSING/COMPLETED` 상태가 정상 반영되지 않거나 피드백 렌더가 지연되는 문제를 수정
* `COMPLETED` 수신 직후 스트림 종료/상세 조회(getAttemptDetails)/상태 반영 순서를 재정리하여, 피드백 데이터가 레이스 없이 안정적으로 렌더되도록 수정

---

## 변경사항
### 1) SSE 커스텀 이벤트(`status-update`) 수신 처리
* 파일: `src/features/levelup-feedback/api/getAttemptStream.ts`
* 내용:
  * 기존 `onmessage`만 수신하던 로직을 보완
  * `EventSource.addEventListener('status-update', ...)` 기반으로 커스텀 이벤트를 파싱/타입가드 적용
* 효과:
  * `PROCESSING`, `COMPLETED` 등 상태 업데이트 이벤트를 정상적으로 수신/반영

### 2) `COMPLETED` 이후 피드백 렌더 레이스 수정
* 파일: `src/features/levelup-feedback/model/useFeedbackStream.ts`
* 내용:
  * `COMPLETED` 수신 직후 스트림 정리와 상세 조회 순서를 정리
  * `getAttemptDetails` 재시도 후 `feedbackData` 세팅이 확실히 반영되도록 보완
* 효과:
  * 완료 이벤트 이후 피드백 화면이 늦게 뜨거나 비어 보이는 현상 완화
  * 완료 직후 상태 전환/데이터 반영이 안정화

---

## Screenshots (UI 변경 시)

---

## How to test

1. 실행

* `pnpm i`
* `pnpm dev`

2. SSE 이벤트 수신 검증

* LevelUp 시도 생성 후 피드백 페이지 진입
* 아래를 확인:
  * SSE 연결이 열리고(`.../stream`) 이벤트가 지속 수신되는지
  * `status-update` 커스텀 이벤트가 들어올 때 상태가 정상 업데이트되는지
  * `PROCESSING`, `COMPLETED` 전환이 누락되지 않는지

3. `COMPLETED` 이후 렌더 레이스 검증

* `COMPLETED` 이벤트 수신 직후:
  * 스트림이 정상적으로 정리(close)되는지
  * `getAttemptDetails` 호출이 수행되는지(필요 시 재시도 포함)
  * `feedbackData`가 세팅되며 화면에 즉시 반영되는지
  * 이전처럼 “완료됐는데 피드백이 늦게 뜨거나 빈 화면”이 재발하지 않는지

---

## 참고 커밋
* `bc61b13` fix: handle sse status-update and completed feedback rendering

> 참고: 이전 SSE 전환/종료 후 재연결 방지(`10866c7`, `d8e5b25`)는 별도 브랜치/머지로 이미 반영된 작업
