### PR TITLE
feat/infra: V3 챌린지 오픈 관련 환경변수를 깃허브 액션에서 CI/CD에 적용하기위해 깃허브 액션 시크릿 3개 추가

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -108,6 +108,7 @@ jobs:
           PERF_BASE_URL: ${{ secrets.PERF_DEV_BASE_URL }}
           ALLOW_E2E_LOGIN: ${{ secrets.ALLOW_DEV_E2E_LOGIN }}
           NEXT_PUBLIC_PVP_OPEN: ${{ secrets.PVP_DEV_OPEN }}
+          NEXT_PUBLIC_CHALLENGE_OPEN: ${{ secrets.CHALLENGE_DEV_OPEN }}
 
         run: |
           echo "=== Build env check (masked) ==="

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -108,6 +108,7 @@ jobs:
           PERF_BASE_URL: ${{ secrets.PERF_PROD_BASE_URL }}
           ALLOW_E2E_LOGIN: ${{ secrets.ALLOW_PROD_E2E_LOGIN }}
           NEXT_PUBLIC_PVP_OPEN: ${{ secrets.PVP_PROD_OPEN }}
+          NEXT_PUBLIC_CHALLENGE_OPEN: ${{ secrets.CHALLENGE_PROD_OPEN }}
         run: pnpm next build
 
   ci-notify-success:
@@ -222,6 +223,7 @@ jobs:
             NEXT_PUBLIC_SECURE=${{ secrets.NEXT_PUBLIC_PROD_SECURE }}
             NEXT_PUBLIC_SERVER_URL=${{ secrets.NEXT_PUBLIC_PROD_SERVER_URL }}
             NEXT_PUBLIC_PVP_OPEN=${{ secrets.PVP_PROD_OPEN }}
+            NEXT_PUBLIC_CHALLENGE_OPEN=${{ secrets.CHALLENGE_PROD_OPEN }}
           tags: |
             219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-frontend:${{ github.sha }}
             219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-frontend:prod-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
           PERF_BASE_URL: ${{ secrets.PERF_RELEASE_BASE_URL }}
           ALLOW_E2E_LOGIN: ${{ secrets.ALLOW_RELEASE_E2E_LOGIN }}
           NEXT_PUBLIC_PVP_OPEN: ${{ secrets.PVP_RELEASE_OPEN }}
+          NEXT_PUBLIC_CHALLENGE_OPEN: ${{ secrets.CHALLENGE_RELEASE_OPEN }}
         run: pnpm next build
 
   ci-notify-success:
@@ -221,6 +222,7 @@ jobs:
             NEXT_PUBLIC_SECURE=${{ secrets.NEXT_PUBLIC_RELEASE_SECURE }}
             NEXT_PUBLIC_SERVER_URL=${{ secrets.NEXT_PUBLIC_RELEASE_SERVER_URL }}
             NEXT_PUBLIC_PVP_OPEN=${{ secrets.PVP_RELEASE_OPEN }}
+            NEXT_PUBLIC_CHALLENGE_OPEN=${{ secrets.CHALLENGE_RELEASE_OPEN }}
           tags: |
             219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-frontend:${{ github.sha }}
             219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-frontend:release-latest


### PR DESCRIPTION
## Summary
- V3 챌린지 오픈 관련 환경변수 추가
- dev.yml, prod.yml, release.yml 워크플로우에 `NEXT_PUBLIC_CHALLENGE_OPEN` 환경변수 추가
- GitHub Secrets에 `CHALLENGE_DEV_OPEN`, `CHALLENGE_PROD_OPEN`, `CHALLENGE_RELEASE_OPEN` 추가 완료

## 환경별 설정값
| 환경 | Secret | 값 |
|------|--------|-----|
| dev | CHALLENGE_DEV_OPEN | true |
| prod | CHALLENGE_PROD_OPEN | false |
| release | CHALLENGE_RELEASE_OPEN | true |

## Test plan
- [ ] dev 브랜치 CI/CD 파이프라인 정상 동작 확인
- [ ] 환경변수가 빌드 시 정상 주입되는지 확인