### PR TITLE
Fix/record duration seconds

### DIFF
--- a/src/_pages/record/ui/LevelUpRecordPage.tsx
+++ b/src/_pages/record/ui/LevelUpRecordPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import { useCardDetails } from '@/features/levelup-feedback'
 import { MicrophoneBox, MicrophoneBoxSkeleton, useLevelUpRecordController } from '@/features/record'
@@ -13,10 +13,15 @@ import type { CardDetails } from '@/features/levelup-feedback'
 
 const RECORD_PROGRESS_VALUE = 100
 const RECORD_STEP_LABEL = '3/3'
+const MINIMUM_SUBMIT_DURATION_SECONDS = 1
+const SUBMIT_ELAPSED_POLL_INTERVAL_MS = 500
 
 type RecordSubmitButtonProps = {
   onComplete: () => Promise<void>
   isSubmitting: boolean
+  isRecording: boolean
+  recordedBlob: Blob | null
+  getElapsedSeconds: () => number
 }
 
 function parseOptionalNumber(value: string | null): number | undefined {
@@ -33,13 +38,36 @@ type LevelUpRecordPageProps = {
 const RecordSubmitButton = memo(function RecordSubmitButton({
   onComplete,
   isSubmitting,
+  isRecording,
+  recordedBlob,
+  getElapsedSeconds,
 }: RecordSubmitButtonProps) {
+  const [hasMinimumDuration, setHasMinimumDuration] = useState(false)
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => {
+      const nextHasMinimumDuration = getElapsedSeconds() >= MINIMUM_SUBMIT_DURATION_SECONDS
+      setHasMinimumDuration((previousHasMinimumDuration) =>
+        previousHasMinimumDuration === nextHasMinimumDuration
+          ? previousHasMinimumDuration
+          : nextHasMinimumDuration,
+      )
+    }, SUBMIT_ELAPSED_POLL_INTERVAL_MS)
+
+    return () => {
+      window.clearInterval(timerId)
+    }
+  }, [getElapsedSeconds])
+
+  const hasRecordedSource = isRecording || Boolean(recordedBlob)
+  const isSubmitDisabled = isSubmitting || !hasRecordedSource || !hasMinimumDuration
+
   return (
     <div className="mt-auto mb-6 flex w-full items-center justify-center gap-4 pt-4">
       <Button
         variant="record_confirm_btn"
         onClick={onComplete}
-        disabled={isSubmitting}
+        disabled={isSubmitDisabled}
       >
         녹음 완료 및 피드백 받기
       </Button>
@@ -113,6 +141,9 @@ export function LevelUpRecordPage({ initialCardDetails }: LevelUpRecordPageProps
       <RecordSubmitButton
         onComplete={handleRecordingComplete}
         isSubmitting={isSubmittingFeedback}
+        isRecording={isRecording}
+        recordedBlob={recordedBlob}
+        getElapsedSeconds={getElapsedSeconds}
       />
       <AlertModal
         open={isBackAlertOpen}

--- a/src/features/pvp/model/usePvPRecordController.ts
+++ b/src/features/pvp/model/usePvPRecordController.ts
@@ -24,6 +24,8 @@ const CREATE_SUBMISSION_ERROR_MESSAGE =
 const UPLOAD_SUBMISSION_ERROR_MESSAGE = '오디오 업로드에 실패했습니다. 다시 시도해주세요.'
 const COMPLETE_SUBMISSION_ERROR_MESSAGE =
   '오디오 업로드 완료 처리에 실패했습니다. 다시 시도해주세요.'
+const MINIMUM_SUBMIT_DURATION_SECONDS = 1
+const TOO_SHORT_RECORDING_ERROR_MESSAGE = '1초 이상 녹음한 뒤 제출해주세요.'
 
 const getFileExtensionFromContentType = (contentType: string) => {
   if (contentType === 'audio/mp4') return FILE_NAME_EXTENSION_MP4
@@ -196,6 +198,12 @@ export function usePvPRecordController({
       const completedBlob = await stopRecordingAndGetBlob()
       if (!completedBlob) {
         toast.error(EMPTY_BLOB_ERROR_MESSAGE)
+        return
+      }
+
+      const durationSeconds = getDurationSeconds()
+      if (durationSeconds < MINIMUM_SUBMIT_DURATION_SECONDS) {
+        toast.error(TOO_SHORT_RECORDING_ERROR_MESSAGE)
         return
       }
 


### PR DESCRIPTION
## 개요
* 너무 짧게(1초 미만) 녹음된 오디오가 제출되는 것을 방지하기 위해, LevelUp/PvP 녹음 제출 조건을 강화
* LevelUp에서는 제출 버튼 자체를`duration ≥ 1초` + 녹음 소스 존재** 조건에서만 활성화
* PvP에서는 제출 직전에 duration을 확인해 1초 미만이면 제출 API 호출을 중단 + 토스트 안내하도록 가드 로직을 추가

---

## 변경사항

### 1) LevelUp 녹음 제출 버튼 활성 조건 강화
* 파일: `src/_pages/record/ui/LevelUpRecordPage.tsx`
* 내용:
  * `RecordSubmitButton`에 `isRecording`, `recordedBlob`, `getElapsedSeconds` 전달
  * 내부에서 500ms 주기로 경과 시간 체크
  * `duration >= 1초`이고 녹음 소스가 있을 때만 제출 버튼 활성화
  * 제출 중 상태에서는 기존처럼 비활성화 유지

### 2) PvP 제출 가드 추가(1초 미만 제출 차단)
* 파일: `src/features/pvp/model/usePvPRecordController.ts`
* 내용:
  * `handlePvPMicClick`에서 녹음 종료 시 `getDurationSeconds()` 확인
  * `1초 미만`이면 제출 API 호출 중단 + 토스트 표시
    * `'1초 이상 녹음한 뒤 제출해주세요.'`

---

## Screenshots (UI 변경 시)

---

## How to test

1. 실행

* `pnpm i`
* `pnpm dev`

2. LevelUp 제출 버튼 조건 확인

* `/levelup/record` 진입
* 녹음을 1초 미만으로 짧게 진행 후 중지

  * 제출 버튼이 **활성화되지 않는지** 확인
* 1초 이상 녹음 후 중지

  * 제출 버튼이 **활성화되는지** 확인
* 제출 진행 중에는 버튼이 기존처럼 비활성화 유지되는지 확인

3. PvP 제출 가드 확인

* PvP 매칭/녹음 화면 진입
* 1초 미만 녹음 후 종료(제출 트리거)

  * 제출 API(create/upload/complete)가 호출되지 않는지 확인
  * 토스트 `'1초 이상 녹음한 뒤 제출해주세요.'` 노출 확인
* 1초 이상 녹음 후 종료

  * 기존 제출 플로우가 정상 동작하는지 확인

---

## 참고 커밋

* `8f083cd` fix: record duration seconds shoud be more than 1 seconds
