### PR TITLE
fix: prevent pvp submission duration from resetting to zero

### DIFF
--- a/src/features/pvp/model/usePvPRecordController.ts
+++ b/src/features/pvp/model/usePvPRecordController.ts
@@ -66,6 +66,8 @@ export function usePvPRecordController({
   roomId,
   roomStatus,
 }: UsePvPRecordControllerParams): UsePvPRecordControllerResult {
+  // 이전 방 상태를 기억해 RECORDING 진입 시점(transition)만 감지한다.
+  const previousRoomStatusRef = useRef<string | null>(null)
   // 로컬 녹음 시작 중복 방지 ref
   const isStartingLocalRecordingRef = useRef(false)
   // 제출(생성/업로드/완료) 중복 실행 방지 ref
@@ -118,7 +120,7 @@ export function usePvPRecordController({
 
   // 제출 공통 플로우: submission 생성 -> 업로드 -> complete
   const submitRecordedBlob = useCallback(
-    async (completedBlob: Blob) => {
+    async (completedBlob: Blob, durationSeconds: number) => {
       if (isSubmittingRef.current || hasSubmittedRef.current) return
 
       // 제출 중복 방지 플래그 on
@@ -162,7 +164,6 @@ export function usePvPRecordController({
         }
 
         // 3) 업로드 완료 후 submission complete 호출
-        const durationSeconds = getDurationSeconds()
         const completeSubmissionResult = await completePvPSubmission(
           createSubmissionResult.data.submissionId,
           { durationSeconds },
@@ -187,7 +188,7 @@ export function usePvPRecordController({
         setIsSubmittingSubmission(false)
       }
     },
-    [getDurationSeconds, roomId],
+    [roomId],
   )
 
   const handlePvPMicClick = async () => {
@@ -207,7 +208,7 @@ export function usePvPRecordController({
         return
       }
 
-      await submitRecordedBlob(completedBlob)
+      await submitRecordedBlob(completedBlob, durationSeconds)
       // 녹음 종료 분기 처리를 끝냈으므로 반환
       return
     }
@@ -218,13 +219,19 @@ export function usePvPRecordController({
     }
   }
 
-  // 방 상태가 RECORDING으로 바뀌면 자동으로 녹음을 시작
+  // 방 상태가 RECORDING으로 "전이"되는 시점에만 자동으로 녹음을 시작
   useEffect(() => {
-    // RECORDING 단계가 아니면 자동 시작하지 않는다.
-    if (!isRecordingStep) return
+    const didEnterRecordingStep =
+      roomStatus === RECORDING_ROOM_STATUS &&
+      previousRoomStatusRef.current !== RECORDING_ROOM_STATUS
+
+    previousRoomStatusRef.current = roomStatus
+
+    if (!didEnterRecordingStep) return
+
     // 비동기 녹음 시작 실행
     void startLocalRecordingIfNeeded()
-  }, [isRecordingStep, startLocalRecordingIfNeeded])
+  }, [roomStatus, startLocalRecordingIfNeeded])
 
   // 60초 auto-stop으로 녹음이 종료된 경우, blob 생성이 완료되면 제출 API를 자동 실행한다.
   useEffect(() => {
@@ -235,11 +242,12 @@ export function usePvPRecordController({
     resetAutoStopped()
 
     const submitAfterAutoStop = async () => {
-      await submitRecordedBlob(recordedBlob)
+      const durationSeconds = getDurationSeconds()
+      await submitRecordedBlob(recordedBlob, durationSeconds)
     }
 
     void submitAfterAutoStop()
-  }, [autoStopped, recordedBlob, resetAutoStopped, submitRecordedBlob])
+  }, [autoStopped, getDurationSeconds, recordedBlob, resetAutoStopped, submitRecordedBlob])
 
   return {
     isRecording,


### PR DESCRIPTION
## 개요
* PvP 제출 완료(`complete`) 요청에 포함되는 `durationSeconds`가 **녹음 종료 직후 0으로 리셋되는 문제**를 수정
* 녹음 종료 시점의 duration을 **고정값으로 캡처**해 제출 플로우 전 구간(create/upload/complete 및 auto-stop)에서 동일하게 사용하도록 통
* `RECORDING` 자동 시작 로직을 **상태 진입 시 1회만 실행**하도록 제한해 종료 직후 재시작 경쟁 상태를 제거

---

## 변경사항
* 파일: `src/features/pvp/model/usePvPRecordController.ts`
### 1) `complete` 요청 durationSeconds 캡처 방식으로 변경
* 제출 완료(`complete`) 요청에 넘기는 `durationSeconds`를
  * “현재 상태에서 다시 계산”하지 않고
  * **녹음 종료 시점에 캡처한 고정값**으로 전달하도록 변경

### 2) `RECORDING` 자동 시작 로직 1회 실행으로 제한
* `RECORDING` 상태에서 자동 녹음 시작이
  * 종료 직후 다시 트리거되며 경쟁 상태를 만들 수 있어
  * **상태 진입 시 1회만** 실행되도록 가드 추가
* 효과: 종료 직후 재시작 → duration 리셋/제출 값 오염 가능성 제거

### 3) auto-stop 제출 경로도 동일 방식으로 통일
* 60초 auto-stop 제출 경로에서도
  * `durationSeconds`를 동일하게 **종료 시점 캡처 값**으로 전달하도록 정리

---

## Screenshots 

---

## How to test

1. 실행

* `pnpm i`
* `pnpm dev`

2. 수동 종료 제출 시나리오 검증(핵심)

* PvP 매칭 → 녹음 시작 → 1초 이상 녹음 후 종료
* Network 탭에서 제출 플로우를 확인:
  * `create submissions`
  * 업로드(presigned)
  * `complete`
* `complete` 요청의 `durationSeconds`가:
  * 종료 직후에도 **0으로 리셋되지 않고**
  * 실제 녹음 길이에 맞는 값으로 전달되는지 확인

3. auto-stop 제출 시나리오 검증
* 60초 auto-stop 발생
* 동일하게 `complete` 요청의 `durationSeconds`가 캡처된 값으로 전달되는지 확인

4. 재시작 경쟁 상태 제거 확인
* `RECORDING` 상태 진입 후 자동 시작이 **1회만** 동작하는지 확인
* 녹음 종료 직후 자동 시작이 재트리거되어 녹음이 다시 시작되거나 duration이 초기화되는 현상이 없는지 확인

---

## 참고 커밋

* `f158b40` fix: prevent pvp submission duration from resetting to zero
